### PR TITLE
[Feature] Tasting Note 상세 페이지 퍼블리싱

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
         "sonner": "^2.0.6",
         "tailwind-merge": "^3.3.1",
         "vaul": "^1.1.2",
+        "yet-another-react-lightbox": "^3.25.0",
         "zod": "^3.25.75",
         "zustand": "^5.0.6"
       },
@@ -8605,6 +8606,29 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/yet-another-react-lightbox": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/yet-another-react-lightbox/-/yet-another-react-lightbox-3.25.0.tgz",
+      "integrity": "sha512-NaCeEXCpdwoTvoOpxNK9gdW8+oHs79yVH+D2YeVQWRjH5i32e5CoXndAAFP2p8awzVYfSonherrE9JMTpfD3EA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@types/react": "^16 || ^17 || ^18 || ^19",
+        "@types/react-dom": "^16 || ^17 || ^18 || ^19",
+        "react": "^16.8.0 || ^17 || ^18 || ^19",
+        "react-dom": "^16.8.0 || ^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "sonner": "^2.0.6",
     "tailwind-merge": "^3.3.1",
     "vaul": "^1.1.2",
+    "yet-another-react-lightbox": "^3.25.0",
     "zod": "^3.25.75",
     "zustand": "^5.0.6"
   },

--- a/src/app/mockup.ts
+++ b/src/app/mockup.ts
@@ -114,3 +114,49 @@ export const communityPostsDetail = [
     content: '글렌피딕 붐따~',
   },
 ];
+
+export const tastingNoteDetail = [
+  {
+    id: '1',
+    alcoholcategory: 'WHISKEY',
+    noteType: 'beginner',
+    title: '발렌타인 30년 블렌디드 스카치 위스키 맛있어요',
+    authorNickname: '닉네임',
+    createdAt: '2024.07.21',
+    views: 2025,
+    profileImage: '/images/avatar.png',
+    content: {
+      images: [
+        '/images/whisky.png',
+        '/images/main-banner.png',
+        '/images/avatar.png',
+        '/images/whisky.png',
+        '/images/whisky.png',
+      ],
+      alchoolName: '발렌타인 30년 블렌디드 스카치 위스키',
+      avb: 40,
+      price: 100000,
+      rate: 4,
+      tasteDate: '2024.07.21',
+      type: '위스키',
+      region: '스코틀랜드',
+      appearance: 14,
+      aroma: [
+        { name: '카라멜', value: 2.5 },
+        { name: '바닐라', value: 3.5 },
+        { name: '오크', value: 4 },
+      ],
+      palate: [
+        { name: '과일', value: 3 },
+        { name: '스파이시', value: 2.5 },
+        { name: '꿀', value: 4 },
+      ],
+      finish: [
+        { name: '오크', value: 3.5 },
+        { name: '스모키', value: 2 },
+        { name: '견과류', value: 4 },
+      ],
+      comment: '처음 마셔보는 위스키였는데, 기대 이상이었어요. 다음에도 꼭 다시 구매하고 싶습니다.',
+    },
+  },
+];

--- a/src/app/mockup.ts
+++ b/src/app/mockup.ts
@@ -114,7 +114,7 @@ export const communityPostsDetail = [
     content: '글렌피딕 붐따~',
   },
 ];
-
+import { AppearanceColor } from '@/components/tasting-note/AppearanceBar';
 export const tastingNoteDetail = [
   {
     id: '1',
@@ -140,7 +140,7 @@ export const tastingNoteDetail = [
       tasteDate: '2024.07.21',
       type: '위스키',
       region: '스코틀랜드',
-      appearance: 14,
+      appearance: 'gold' as AppearanceColor,
       aroma: [
         { name: '카라멜', value: 2.5 },
         { name: '바닐라', value: 3.5 },

--- a/src/app/tasting-note/[id]/page.tsx
+++ b/src/app/tasting-note/[id]/page.tsx
@@ -2,18 +2,11 @@ import BackButton from '@/components/common/BackButton';
 import { tastingNoteDetail } from '@/app/mockup';
 import PostTitle from '@/components/common/PostTitle';
 import { toAlcoholLabel } from '@/utils/alcoholTypeConvertor';
-import Image from 'next/image';
 import Rating from '@/components/common/Rating';
 import CommentSection from '@/components/comment/CommentSection';
-import {
-  Carousel,
-  CarouselContent,
-  CarouselItem,
-  CarouselPrevious,
-  CarouselNext,
-} from '@/components/ui/carousel';
 import AppearanceBar from '@/components/tasting-note/AppearanceBar';
 import { FlavorTile } from '@/components/tasting-note/FlavorSelector';
+import ImageGallery from '@/components/ImageGallery';
 
 export default function TastingNoteDetailPage() {
   const data = tastingNoteDetail[0];
@@ -30,23 +23,8 @@ export default function TastingNoteDetailPage() {
         views={data.views}
       />
       <div className="flex flex-col gap-9">
-        <Carousel className="w-full">
-          <CarouselContent>
-            {data.content.images.map((image, index) => (
-              <CarouselItem key={index} className="relative md:basis-1/2 lg:basis-1/3">
-                <div className="h-100 relative">
-                  <Image src={image} alt={`tasting-note-${index}`} fill className="object-cover" />
-                </div>
-              </CarouselItem>
-            ))}
-          </CarouselContent>
-          {data.content.images?.length > 3 && (
-            <>
-              <CarouselPrevious className="-left-10" />
-              <CarouselNext className="-right-10" />
-            </>
-          )}
-        </Carousel>
+        {/* Image Gallery */}
+        <ImageGallery images={data.content.images} />
 
         <dl className="flex flex-col gap-9 px-5">
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-x-10 gap-y-6 ">

--- a/src/app/tasting-note/[id]/page.tsx
+++ b/src/app/tasting-note/[id]/page.tsx
@@ -1,3 +1,105 @@
+import BackButton from '@/components/common/BackButton';
+import { tastingNoteDetail } from '@/app/mockup';
+import PostTitle from '@/components/common/PostTitle';
+import { toAlcoholLabel } from '@/utils/alcoholTypeConvertor';
+import Image from 'next/image';
+import Rating from '@/components/common/Rating';
+import CommentSection from '@/components/comment/CommentSection';
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselPrevious,
+  CarouselNext,
+} from '@/components/ui/carousel';
+
 export default function TastingNoteDetailPage() {
-  return <div>TastingNoteDetailPage</div>;
+  const data = tastingNoteDetail[0];
+  return (
+    <div className="flex flex-col gap-10 mx-30 mb-30">
+      <BackButton>Tasting Note</BackButton>
+      <PostTitle
+        id={data.id}
+        boardType={toAlcoholLabel(data.alcoholcategory)}
+        title={data.title}
+        proileImage={data.profileImage}
+        authorNickname={data.authorNickname}
+        createdAt={data.createdAt}
+        views={data.views}
+      />
+      <div className="flex flex-col gap-9">
+        <Carousel className="w-full">
+          <CarouselContent>
+            {data.content.images.map((image, index) => (
+              <CarouselItem key={index} className="relative md:basis-1/2 lg:basis-1/3">
+                <div className="h-100 relative">
+                  <Image src={image} alt={`tasting-note-${index}`} fill className="object-cover" />
+                </div>
+              </CarouselItem>
+            ))}
+          </CarouselContent>
+          {data.content.images?.length > 3 && (
+            <>
+              <CarouselPrevious className="-left-10" />
+              <CarouselNext className="-right-10" />
+            </>
+          )}
+        </Carousel>
+
+        <dl className="flex flex-col gap-9 px-5">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-x-10 gap-y-6 ">
+            <div className="flex gap-7 items-center">
+              <dt className="w-30 text-head5 text-black">이름</dt>
+              <dd className="text-body1 text-black">{data.content.alchoolName}</dd>
+            </div>
+
+            <div className="flex gap-7 items-center">
+              <dt className="w-30 text-head5 text-black">시음 날짜</dt>
+              <dd className="text-body1 text-black">{data.content.tasteDate}</dd>
+            </div>
+
+            <div className="flex gap-7 items-center">
+              <dt className="w-30 text-head5 text-black">알코올 도수</dt>
+              <dd className="text-body1 text-black">{data.content.avb}도</dd>
+            </div>
+
+            <div className="flex gap-7 items-center">
+              <dt className="w-30 text-head5 text-black">종류</dt>
+              <dd className="text-body1 text-black">{toAlcoholLabel(data.alcoholcategory)}</dd>
+            </div>
+
+            <div className="flex gap-7 items-center">
+              <dt className="w-30 text-head5 text-black">가격</dt>
+              <dd className="text-body1 text-black">
+                {data.content.price.toLocaleString('ko-KR')}
+              </dd>
+            </div>
+
+            <div className="flex gap-7 items-center">
+              <dt className="w-30 text-head5 text-black">지역</dt>
+              <dd className="text-body1 text-black">{data.content.region}</dd>
+            </div>
+
+            <div className="flex gap-7 items-center">
+              <dt className="w-30 text-head5 text-black">별점</dt>
+              <dd className="text-body1 text-black">
+                <Rating rating={data.content.rate} size={40} />
+              </dd>
+            </div>
+          </div>
+
+          <dt className="text-head5 text-black">Appearance(외관)</dt>
+          <dt className="text-head5 text-black">Aroma(향)</dt>
+          <dt className="text-head5 text-black">Palate(맛)</dt>
+          <dt className="text-head5 text-black">Finish(피니시)</dt>
+          <div>
+            <dt className="text-head5 text-black">Comment</dt>
+            <dd className="text-body1 text-black whitespace-pre-wrap">{data.content.comment}</dd>
+          </div>
+        </dl>
+
+        <CommentSection postId={data.id} />
+      </div>
+    </div>
+  );
 }

--- a/src/app/tasting-note/[id]/page.tsx
+++ b/src/app/tasting-note/[id]/page.tsx
@@ -12,6 +12,8 @@ import {
   CarouselPrevious,
   CarouselNext,
 } from '@/components/ui/carousel';
+import AppearanceBar from '@/components/tasting-note/AppearanceBar';
+import { FlavorTile } from '@/components/tasting-note/FlavorSelector';
 
 export default function TastingNoteDetailPage() {
   const data = tastingNoteDetail[0];
@@ -88,10 +90,46 @@ export default function TastingNoteDetailPage() {
             </div>
           </div>
 
+          {/* Appearance */}
           <dt className="text-head5 text-black">Appearance(외관)</dt>
-          <dt className="text-head5 text-black">Aroma(향)</dt>
-          <dt className="text-head5 text-black">Palate(맛)</dt>
-          <dt className="text-head5 text-black">Finish(피니시)</dt>
+          {data.noteType === 'beginner' ? (
+            <div className="w-full">
+              <AppearanceBar value={data.content.appearance} detailed={false} showLabel={false} />
+            </div>
+          ) : (
+            <div className="w-full">
+              <AppearanceBar value={data.content.appearance} detailed showLabel={false} />
+            </div>
+          )}
+
+          {/* Aroma, Palate, Finish */}
+          <div className="flex flex-col gap-3">
+            <dt className="text-head5 text-black">Aroma(향)</dt>
+            <dd className="flex gap-4">
+              {data.content.aroma.map(f => (
+                <FlavorTile key={f.name} label={f.name} score={f.value} className="w-32" />
+              ))}
+            </dd>
+          </div>
+
+          <div className="flex flex-col gap-3">
+            <dt className="text-head5 text-black">Palate(맛)</dt>
+            <dd className="flex gap-4">
+              {data.content.palate.map(f => (
+                <FlavorTile key={f.name} label={f.name} score={f.value} className="w-32" />
+              ))}
+            </dd>
+          </div>
+
+          <div className="flex flex-col gap-3">
+            <dt className="text-head5 text-black">Finish(피니시)</dt>
+            <dd className="flex gap-4">
+              {data.content.finish.map(f => (
+                <FlavorTile key={f.name} label={f.name} score={f.value} className="w-32" />
+              ))}
+            </dd>
+          </div>
+          {/* Comment */}
           <div>
             <dt className="text-head5 text-black">Comment</dt>
             <dd className="text-body1 text-black whitespace-pre-wrap">{data.content.comment}</dd>

--- a/src/components/ImageGallery.tsx
+++ b/src/components/ImageGallery.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselPrevious,
+  CarouselNext,
+} from '@/components/ui/carousel';
+import Lightbox from 'yet-another-react-lightbox';
+import 'yet-another-react-lightbox/styles.css';
+
+import Image from 'next/image';
+import { useState } from 'react';
+
+export default function ImageGallery({ images }: { images: string[] }) {
+  const [imageIndex, setImageIndex] = useState(-1);
+  const slides = images.map(src => ({ src }));
+
+  return (
+    <Carousel>
+      <CarouselContent>
+        {images.map((image, index) => (
+          <CarouselItem
+            key={index}
+            className="relative md:basis-1/2 lg:basis-1/3"
+            onClick={() => setImageIndex(index)}
+          >
+            <div className="h-100 relative">
+              <Image src={image} alt={`tasting-note-${index}`} fill className="object-cover" />
+            </div>
+          </CarouselItem>
+        ))}
+      </CarouselContent>
+      <Lightbox
+        slides={slides}
+        index={imageIndex}
+        open={imageIndex >= 0}
+        close={() => setImageIndex(-1)}
+        styles={{
+          root: { '--yarl__color_backdrop': 'rgba(0, 0, 0, .8)' },
+        }}
+      />
+      {images.length > 3 && (
+        <>
+          <CarouselPrevious className="-left-10" />
+          <CarouselNext className="-right-10" />
+        </>
+      )}
+    </Carousel>
+  );
+}

--- a/src/components/common/PostTitle.tsx
+++ b/src/components/common/PostTitle.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import Image from 'next/image';
+import PostActionMenu from '@/components/common/PostActionMenu';
+
+export default function PostTitle({
+  id,
+  boardType,
+  title,
+  proileImage,
+  authorNickname,
+  createdAt,
+  views,
+}: {
+  id: string;
+  boardType: string;
+  title: string;
+  proileImage?: string;
+  authorNickname: string;
+  createdAt: string;
+  views: number;
+}) {
+  const currentUserId = '1'; // 더보기 메뉴 테스트용 임시 유저 아이디
+
+  return (
+    <div className="flex flex-col align-start gap-2.5">
+      <h6 className="text-head6 text-sub-1">{boardType}</h6>
+      <h3 className="text-head3 text-black">{title}</h3>
+      <div className="flex items-center place-content-between">
+        <div className="flex items-center gap-2.5">
+          <Image
+            src={proileImage || '/images/default-profile.png'}
+            alt="profile"
+            width={50}
+            height={50}
+            className="rounded-full"
+          />
+          <span className="text-head6 text-black">{authorNickname}</span>
+        </div>
+        <div>
+          <dl className="flex gap-10 items-center text-black">
+            <div className="flex gap-2.5 items-center">
+              <dt className="text-head6">작성</dt>
+              <dd className="text-body2">{createdAt}</dd>
+            </div>
+            <div className="flex gap-2.5 items-center">
+              <dt className="text-head6">조회수</dt>
+              <dd className="text-body2">{views}</dd>
+            </div>
+            <PostActionMenu postId={id} isOwner={id === currentUserId} />
+          </dl>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/tasting-note/AppearanceBar.tsx
+++ b/src/components/tasting-note/AppearanceBar.tsx
@@ -1,0 +1,238 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+export type AppearanceColor = 'pale' | 'straw' | 'gold' | 'amber' | 'mahogany';
+
+/**
+ * PALETTE: 초심자용(5범주) + 고급용(세부 셰이드) 색상/라벨의 단일 소스
+ * - baseHex: 초심자 모드에서 각 범주의 배경색
+ * - shades: 고급 모드에서 표시되는 세부 구간(좌→우 순서)
+ */
+const PALETTE: {
+  key: AppearanceColor;
+  label: string;
+  baseHex: string;
+  shades: { hex: string; label: string }[];
+}[] = [
+  // 1) Pale
+  {
+    key: 'pale',
+    label: 'Pale',
+    baseHex: '#FFFFFF',
+    shades: [
+      { hex: '#FFFFFF', label: 'Gin Clear (무색, 투명)' },
+      { hex: '#FEFCDD', label: 'White Wine (화이트 와인)' },
+      { hex: '#FEEE98', label: 'Pale Straw (옅은 짚색)' },
+      { hex: '#FBEA77', label: 'Pale Gold (옅은 금색)' },
+    ],
+  },
+
+  // 2) Straw
+  {
+    key: 'straw',
+    label: 'Straw',
+    baseHex: '#FBE166',
+    shades: [
+      { hex: '#FBE166', label: 'Jonquil / Pale Corn (노랑 옥수수빛)' },
+      { hex: '#FADB56', label: 'Yellow Gold (노란 금색)' },
+      { hex: '#FAD54A', label: 'Old Gold (올드 골드)' },
+      { hex: '#FACD4B', label: 'Amber (호박색)' },
+      { hex: '#F7C751', label: 'Deep Gold (짙은 금색)' },
+    ],
+  },
+
+  // 3) Gold
+  {
+    key: 'gold',
+    label: 'Gold',
+    baseHex: '#E79E13',
+    shades: [
+      { hex: '#F7C23B', label: 'Amontillado Sherry (아몬틸라도 셰리)' },
+      { hex: '#F3BD33', label: 'Deep Copper (짙은 구리)' },
+      { hex: '#EBAD07', label: 'Burnished (광택 구리/금속)' },
+      { hex: '#E79E13', label: 'Chestnut / Oloroso Sherry (밤빛/올로로소 셰리)' },
+    ],
+  },
+
+  // 4) Amber
+  {
+    key: 'amber',
+    label: 'Amber',
+    baseHex: '#CC502E',
+    shades: [
+      { hex: '#E59403', label: 'Russet / Muscat (적갈색/머스캣)' },
+      { hex: '#DD7317', label: 'Tawny (토니 포트색)' },
+      { hex: '#E26529', label: 'Auburn / Polished Mahogany (적갈 마호가니)' },
+      { hex: '#CC502E', label: 'Mahogany (마호가니)' },
+    ],
+  },
+
+  // 5) Mahogany
+  {
+    key: 'mahogany',
+    label: 'Mahogany',
+    baseHex: '#702C1D',
+    shades: [
+      { hex: '#B22E29', label: 'Fenna Notes (흙내/페놀틱 노트)' },
+      { hex: '#9A251E', label: 'Burnt Timber (탄 나무)' },
+      { hex: '#702C1D', label: 'Old Oak (올드 오크)' },
+      { hex: '#421C0B', label: 'Brown Sherry / Treacle (진한 셰리/당밀)' },
+    ],
+  },
+];
+// 범주 키 -> 범주 라벨 매핑 (초심자)
+const LABELS: Record<AppearanceColor, string> = Object.fromEntries(
+  PALETTE.map(s => [s.key, s.label])
+) as Record<AppearanceColor, string>;
+
+/**
+ * FLAT_SHADES: 고급 모드 렌더를 위해 모든 셰이드를 1차원 배열로 평탄화
+ * - segKey: 이 셰이드가 속한 5범주 키
+ * - idx: 전체 막대에서의 전역 인덱스 (좌->우)
+ */
+
+const FLAT_SHADES = (() => {
+  const out: { hex: string; label: string; segKey: AppearanceColor; idx: number }[] = [];
+  let idx = 0;
+  for (const seg of PALETTE) {
+    for (const shade of seg.shades) {
+      out.push({ hex: shade.hex, label: shade.label, segKey: seg.key, idx });
+      idx += 1;
+    }
+  }
+  return out;
+})();
+
+/**
+ * SEGMENT_INDEX: 각 5범주가 차지하는 전역 인덱스 구간과 대표 인덱스(가운데 값)
+ * - start/end: FLAT_SHADES에서의 시작/끝 인덱스
+ * - rep: 시각적 강조에 사용할 대표 인덱스(가운데)
+ */
+
+const SEGMENT_INDEX: Record<AppearanceColor, { start: number; end: number; rep: number }> = (() => {
+  const map = {} as Record<AppearanceColor, { start: number; end: number; rep: number }>;
+  let cursor = 0;
+  for (const seg of PALETTE) {
+    const count = seg.shades.length;
+    const start = cursor;
+    const end = cursor + count - 1;
+    const rep = Math.round((start + end) / 2);
+    map[seg.key] = { start, end, rep };
+    cursor = end + 1;
+  }
+  return map;
+})();
+
+/* 전역 인덱스 -> 해당하는 5범주 키 */
+function binOfIndex(globalIdx: number): AppearanceColor {
+  for (const seg of PALETTE) {
+    const { start, end } = SEGMENT_INDEX[seg.key];
+    if (globalIdx >= start && globalIdx <= end) return seg.key;
+  }
+  return 'gold';
+}
+
+/* 5범주 키 -> 대표 인덱스(가운데 칸) */
+function representativeIndexOfBin(key: AppearanceColor): number {
+  return SEGMENT_INDEX[key].rep;
+}
+
+export default function AppearanceBar({
+  value,
+  onChange,
+  className = '',
+  showLabel = true,
+  detailed = false,
+}: {
+  value: AppearanceColor | null; // 현재 선택된 5범주
+  onChange?: (v: AppearanceColor) => void;
+  className?: string;
+  showLabel?: boolean; // 하단 라벨 표시 여부
+  detailed?: boolean; // true = expert, false = beginner
+}) {
+  const [shadeIdx, setShadeIdx] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!detailed) {
+      setShadeIdx(null);
+      return;
+    }
+    if (value) {
+      setShadeIdx(prev => (prev === null ? representativeIndexOfBin(value) : prev));
+    } else {
+      setShadeIdx(null);
+    }
+  }, [detailed, value]);
+
+  const labelToShow = useMemo(() => {
+    if (detailed && shadeIdx !== null && FLAT_SHADES[shadeIdx]) {
+      return FLAT_SHADES[shadeIdx].label;
+    }
+    return value ? LABELS[value] : '선택 없음';
+  }, [detailed, shadeIdx, value]);
+
+  const selectedIdx = useMemo(() => {
+    if (!detailed) return -1;
+    if (shadeIdx !== null) return shadeIdx;
+    return value ? representativeIndexOfBin(value) : -1;
+  }, [detailed, shadeIdx, value]);
+
+  return (
+    <div className={`w-full ${className}`}>
+      <div
+        className="w-full h-6 sm:h-7 md:h-8 rounded-none overflow-hidden border border-gray-300 bg-white"
+        role="radiogroup"
+        aria-label="Appearance"
+      >
+        <div className="flex h-full">
+          {detailed // expert mode
+            ? FLAT_SHADES.map((s, i) => {
+                const isSelected = i === selectedIdx;
+                return (
+                  <button
+                    key={i}
+                    type="button"
+                    aria-checked={isSelected}
+                    role="radio"
+                    onClick={() => {
+                      setShadeIdx(i);
+                      onChange && onChange(binOfIndex(i));
+                    }}
+                    className="flex-1 h-full focus:outline-none focus-visible:ring-2 focus-visible:ring-black/20 cursor-pointer"
+                    style={{
+                      backgroundColor: s.hex,
+
+                      boxShadow: isSelected ? 'inset 0 0 0 2px #301700ff' : undefined,
+                    }}
+                    title={s.label}
+                  />
+                );
+              })
+            : // beginner mode
+              PALETTE.map(seg => {
+                const isSelected = value === seg.key;
+                return (
+                  <button
+                    key={seg.key}
+                    type="button"
+                    aria-checked={isSelected}
+                    role="radio"
+                    onClick={() => onChange && onChange(seg.key)}
+                    className="flex-1 h-full focus:outline-none focus-visible:ring-2 focus-visible:ring-black/20 cursor-pointer"
+                    style={{
+                      backgroundColor: seg.baseHex,
+
+                      boxShadow: isSelected ? 'inset 0 0 0 3px #000' : undefined,
+                    }}
+                    title={seg.label}
+                  />
+                );
+              })}
+        </div>
+      </div>
+
+      {showLabel && <div className="mt-2 text-xs text-gray-600">선택: {labelToShow}</div>}
+    </div>
+  );
+}

--- a/src/components/tasting-note/FlavorSelector.tsx
+++ b/src/components/tasting-note/FlavorSelector.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import IntensityPopover from '@/components/tasting-note/IntensityPopover';
+import { twMerge } from 'tailwind-merge';
+export type FlavorGroup = 'Aroma' | 'Palate' | 'Finish';
+export type FlavorGroupSelection = Record<FlavorGroup, Record<string, number>>;
+
+const VOCABS: Record<FlavorGroup, string[]> = {
+  Aroma: [
+    '꿀,설탕,시럽',
+    '카라멜',
+    '바닐라,버터',
+    '사과,배',
+    '감귤',
+    '바나나,망고',
+    '말린 자두, 무화과',
+    '체리,라즈베리',
+    '곡물,빵,견과류',
+    '시나몬',
+    '초콜릿,커피',
+    '바다',
+    '나무',
+    '약품',
+  ],
+  Palate: [
+    '꿀,설탕,시럽',
+    '카라멜',
+    '바닐라,버터',
+    '사과,배',
+    '감귤',
+    '바나나,망고',
+    '말린 자두, 무화과',
+    '체리,라즈베리',
+    '곡물,빵,견과류',
+    '시나몬',
+    '초콜릿,커피',
+    '바다',
+    '나무',
+    '약품',
+  ],
+  Finish: [
+    '꿀,설탕,시럽',
+    '카라멜',
+    '바닐라,버터',
+    '사과,배',
+    '감귤',
+    '바나나,망고',
+    '말린 자두, 무화과',
+    '체리,라즈베리',
+    '곡물,빵,견과류',
+    '시나몬',
+    '초콜릿,커피',
+    '바다',
+    '나무',
+    '약품',
+  ],
+};
+
+export default function FlavorSelector({
+  value,
+  onChange,
+}: {
+  value: FlavorGroupSelection;
+  onChange: (v: FlavorGroupSelection) => void;
+}) {
+  const [tab, setTab] = useState<FlavorGroup>('Aroma');
+  const setScore = (group: FlavorGroup, label: string, score: number) => {
+    const next = { ...value, [group]: { ...(value[group] || {}) } };
+    if (score <= 0) delete next[group][label];
+    else next[group][label] = score;
+    onChange(next);
+  };
+
+  return (
+    <div className="rounded-2xl border border-gray-200 bg-gray-50 p-4">
+      <div className="mb-4 flex gap-2">
+        {(['Aroma', 'Palate', 'Finish'] as FlavorGroup[]).map(t => {
+          const active = tab === t;
+          return (
+            <button
+              key={t}
+              type="button"
+              onClick={() => setTab(t)}
+              className={`rounded-lg px-3 py-1 text-sm transition
+                ${active ? 'bg-amber-400 text-[#653205] font-semibold' : 'bg-white text-[#653205] border border-brown-200 font-semibold'}`}
+            >
+              {t}
+            </button>
+          );
+        })}
+      </div>
+
+      <div
+        className="grid grid-cols-2 gap-3 sm:[grid-template-columns:repeat(var(--cols),minmax(0,1fr))]"
+        style={{ ['--cols' as any]: Math.ceil(VOCABS[tab].length / 2) }}
+      >
+        {VOCABS[tab].map(label => (
+          <FlavorTile
+            key={label}
+            label={label}
+            score={value[tab]?.[label] ?? 0}
+            onChange={s => setScore(tab, label, s)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function FlavorTile({
+  label,
+  score,
+  onChange,
+  className,
+}: {
+  label: string;
+  score: number; // 0~5
+  onChange?: (s: number) => void;
+  className?: string;
+}) {
+  const stateClass = useMemo(() => {
+    return score > 0
+      ? 'bg-amber-300 border-amber-400'
+      : 'bg-white border-brown-200 hover:border-amber-400';
+  }, [score]);
+
+  // 클릭 시 선택/해제 토글(선택 시 기본값 2.5)
+  const toggleSelect = () => (score > 0 ? onChange && onChange(0) : onChange && onChange(2.5));
+
+  return (
+    <IntensityPopover
+      label={`${label} 강도 조절`}
+      value={score}
+      onChange={v => onChange && onChange(Math.max(0, Math.min(5, v)))}
+      width={260}
+      asChild
+    >
+      <div className={twMerge('relative', className)}>
+        <div
+          role="button"
+          tabIndex={0}
+          onClick={toggleSelect} // 팝업 열리면서 선택 토글
+          className={`group h-20 w-full rounded-lg border text-sm text-brown-800 transition ${stateClass}`}
+        >
+          <span className="px-3">{label}</span>
+
+          {score > 0 && (
+            <>
+              <span className="absolute bottom-1 left-1 rounded-md bg-white px-1.5 text-xs font-semibold">
+                {score.toFixed(1)}
+              </span>
+              {onChange && (
+                <button
+                  type="button"
+                  className="absolute right-1 top-1 rounded-full bg-white/90 px-1 text-xs shadow"
+                  onClick={e => {
+                    e.stopPropagation();
+                    onChange && onChange(0);
+                  }}
+                  aria-label="remove"
+                >
+                  ✕
+                </button>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </IntensityPopover>
+  );
+}

--- a/src/components/tasting-note/IntensityPopover.tsx
+++ b/src/components/tasting-note/IntensityPopover.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import * as React from 'react';
+import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover';
+import { Slider } from '@/components/ui/slider';
+
+type Props = {
+  label: string;
+  value: number;
+  onChange: (v: number) => void;
+  min?: number;
+  max?: number;
+  step?: number;
+  asChild?: boolean;
+  children?: React.ReactNode;
+  width?: number;
+};
+
+export default function IntensityPopover({
+  label,
+  value,
+  onChange,
+  min = 0,
+  max = 5,
+  step = 0.1,
+  asChild = false,
+  children,
+  width = 200,
+}: Props) {
+  const [open, setOpen] = React.useState(false);
+
+  /* pop은 slider 부분 밑에 사각형을 어울리게 배치해서 말풍선 모양 만듦 */
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        {asChild && children ? (
+          children
+        ) : (
+          <button
+            type="button"
+            className="h-7 w-7 rounded-md text-[#653205] focus:outline-none"
+            aria-label={label}
+          >
+            ▼
+          </button>
+        )}
+      </PopoverTrigger>
+      <PopoverContent
+        side="top"
+        align="center"
+        sideOffset={12}
+        className="
+          group/pc relative z-50 overflow-visible
+          rounded-[20px] border-[2px] border-[#653205] bg-white p-2
+          shadow-none outline-none
+       "
+        style={{ width, height: 45 }}
+      >
+        <div className="flex items-center gap-4">
+          <Slider
+            min={min}
+            max={max}
+            step={step}
+            value={[value]}
+            onValueChange={arr => onChange(arr[0] ?? min)}
+            className="
+            w-full
+            /* 트랙 배경 */
+            [&_[data-slot=slider-track]]:!bg-[#DADAD7]
+            [&_[data-slot=slider-track]]:h-[5px]
+            [&_[data-slot=slider-track]]:rounded-[4px]
+
+            /* 채워지는 부분(갈색) */
+            [&_[data-slot=slider-range]]:!bg-[#653205]
+            [&_[data-slot=slider-range]]:h-[5px]
+            [&_[data-slot=slider-range]]:rounded-[4px]
+
+            /* 썸(갈색) */
+            [&_[data-slot=slider-thumb]]:!bg-[#653205]
+            [&_[data-slot=slider-thumb]]:h-[16px]
+            [&_[data-slot=slider-thumb]]:w-[16px]
+            [&_[data-slot=slider-thumb]]:rounded-full
+            [&_[data-slot=slider-thumb]]:border-0
+            [&_[data-slot=slider-thumb]]:shadow-none
+          "
+          />
+          <div className="w-[30px] text-right font-semibold text-[20px] leading-[120%] text-[#0C0C0C]">
+            {value.toFixed(1)}
+          </div>
+        </div>
+        {/* 사각형 */}
+        <span
+          aria-hidden
+          className="
+            pointer-events-none absolute left-1/2 -translate-x-1/2
+            group-data-[side=top]/pc:-bottom-[8px]
+            h-[14px] w-[14px] rotate-45 bg-white
+            border-b-[2px] border-r-[2px] border-[#653205]
+            rounded-[1px]
+          "
+        />
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/constants/enum/alcoholType.ts
+++ b/src/constants/enum/alcoholType.ts
@@ -1,0 +1,26 @@
+const AlcoholCategory = {
+  WHISKEY: '위스키',
+  WINE: '와인',
+  OTHER: '기타',
+} as const;
+
+const SubAlcoholCategory = {
+  SINGLE_MALT: '싱글몰트',
+  BLENDED: '블렌디드',
+  BOURBON: '버번',
+  RED: 'Red',
+  WHITE: 'White',
+  SPARKLING: 'Sparkling',
+  ROSE: 'Rose',
+  SAKE: '사케',
+  CHINESE_LIQUOR: '중국술',
+  TRADITIONAL: '전통주',
+} as const;
+
+type AlcoholKey = keyof typeof AlcoholCategory;
+type AlcoholLabel = (typeof AlcoholCategory)[AlcoholKey];
+type SubAlcoholKey = keyof typeof SubAlcoholCategory;
+type SubAlcoholLabel = (typeof SubAlcoholCategory)[SubAlcoholKey];
+
+export { AlcoholCategory, SubAlcoholCategory };
+export type { AlcoholKey, AlcoholLabel, SubAlcoholKey, SubAlcoholLabel };

--- a/src/utils/alcoholTypeConvertor.ts
+++ b/src/utils/alcoholTypeConvertor.ts
@@ -1,0 +1,25 @@
+import { AlcoholCategory, SubAlcoholCategory } from '@/constants/enum/alcoholType';
+import {
+  AlcoholKey,
+  AlcoholLabel,
+  SubAlcoholKey,
+  SubAlcoholLabel,
+} from '@/constants/enum/alcoholType';
+
+export function toAlcoholLabel(key: string): AlcoholLabel {
+  return AlcoholCategory[key as AlcoholKey];
+}
+
+export function toAlcoholKey(label: AlcoholLabel): AlcoholKey | undefined {
+  const entry = Object.entries(AlcoholCategory).find(([, v]) => v === label);
+  return entry?.[0] as AlcoholKey | undefined;
+}
+
+export function toSubAlcoholLabel(key: string): SubAlcoholLabel {
+  return SubAlcoholCategory[key as SubAlcoholKey];
+}
+
+export function toSubAlcoholKey(label: SubAlcoholLabel): SubAlcoholKey | undefined {
+  const entry = Object.entries(SubAlcoholCategory).find(([, v]) => v === label);
+  return entry?.[0] as SubAlcoholKey | undefined;
+}


### PR DESCRIPTION
## 1️⃣ 작업 내용 Summary
Tasting Note 상세 페이지 뷰 제작했습니다.
AppearanceBar랑 Aroma, Palate, Finish에 쓰이는 타일은 승종오빠가 만든거 가져와서 썼어용

- resolved #25 

## 2️⃣ 추후 작업할 내용
- FlavorTile 아이콘 형태로 디자인 확정되면 교체
- 그래프 부분 디자인 나오면 추가

## 3️⃣ 체크리스트

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
