### PR TITLE
Refactor/UI improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
 # dependencies
-node_modules/s
 /node_modules
 /.pnp
 .pnp.*

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
 # dependencies
+node_modules/s
 /node_modules
 /.pnp
 .pnp.*

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -1,0 +1,67 @@
+import { apiInstance } from '@/api/instance';
+import { z } from 'zod';
+
+const myProfileSchema = z.object({
+  id: z.coerce.number(),
+  socialType: z.string(),
+  nickname: z.string(),
+  profileImageUrl: z.string().nullable(),
+  wishCnt: z.coerce.number(),
+  noteCnt: z.coerce.number(),
+  createdAt: z.union([z.string(), z.date()]),
+});
+
+export type MyProfile = z.infer<typeof myProfileSchema>;
+const publicProfileSchema = z.object({
+  id: z.coerce.number(),
+  nickname: z.string(),
+  profileImageUrl: z.string().nullable(),
+  wishCnt: z.coerce.number(),
+  noteCnt: z.coerce.number(),
+  createdAt: z.union([z.string(), z.date()]),
+});
+
+export type PublicProfile = z.infer<typeof publicProfileSchema>;
+const updateMyProfileRequestSchema = z.object({
+  nickname: z.string().min(2).max(20).optional(),
+  profileImageUrl: z.string().nullable().optional(),
+});
+
+export type UpdateMyProfileRequest = z.infer<typeof updateMyProfileRequestSchema>;
+
+export async function getMyProfile(): Promise<MyProfile> {
+  const { data } = await apiInstance.get<unknown>('users/my');
+  return myProfileSchema.parse(data);
+}
+
+export async function getPublicProfile(userId: number): Promise<PublicProfile> {
+  const { data } = await apiInstance.get<unknown>(`users/${userId}`);
+  return publicProfileSchema.parse(data);
+}
+
+export async function updateMyProfile(request: UpdateMyProfileRequest): Promise<MyProfile> {
+  const payload = updateMyProfileRequestSchema.parse(request);
+  const { data } = await apiInstance.post<unknown>('users/my', payload);
+  return myProfileSchema.parse(data);
+}
+
+export async function fileToDataUrl(file: File): Promise<string> {
+  return await new Promise((resolve, reject) => {
+    const reader = new FileReader();
+
+    reader.onload = () => {
+      if (typeof reader.result === 'string') {
+        resolve(reader.result);
+        return;
+      }
+
+      reject(new Error('이미지 파일을 읽는 데 실패했어요.'));
+    };
+
+    reader.onerror = () => {
+      reject(new Error('이미지 파일을 읽는 데 실패했어요.'));
+    };
+
+    reader.readAsDataURL(file);
+  });
+}

--- a/src/app/AppWrapper.tsx
+++ b/src/app/AppWrapper.tsx
@@ -13,10 +13,10 @@ export default function AppWrapper({ children }: { children: ReactNode }) {
   const showFooter = !hideFooterRoutes.includes(pathname);
 
   return (
-    <>
+    <div className="flex min-h-screen flex-col">
       <Navibar />
-      {children}
+      <div className="flex flex-1 flex-col">{children}</div>
       {showFooter && <Footer />}
-    </>
+    </div>
   );
 }

--- a/src/app/community/page.tsx
+++ b/src/app/community/page.tsx
@@ -8,9 +8,9 @@ import PostsPagination from '@/components/common/PostsPagination';
 import { useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
-import { alcoholListQueryOptions } from '@/query/options/alcohol';
 import Link from 'next/link';
 import AuthGuard from '@/components/auth/AuthGuard';
+import { listPosts, type PostCategory } from '@/api/posts';
 
 export default function CommunityPage() {
   return (
@@ -23,22 +23,29 @@ export default function CommunityPage() {
 function CommunityPageContent() {
   const [currentPage, setCurrentPage] = useState(1);
   const [query, setQuery] = useState('');
+  const [selectedCategory, setSelectedCategory] = useState<PostCategory>('FREE');
   const router = useRouter();
 
-  const queryOptions = useMemo(
-    () =>
-      alcoholListQueryOptions({
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['community', 'posts', currentPage, selectedCategory],
+    queryFn: () =>
+      listPosts({
         page: currentPage,
         size: 9,
-        sort: 'View',
-        query,
+        category: selectedCategory,
+        sort: 'createdAt',
       }),
-    [currentPage, query]
-  );
+    retry: false,
+    throwOnError: false,
+  });
 
-  const { data, isLoading, isError } = useQuery(queryOptions);
-  const items = data?.items ?? [];
-  const totalPages = data?.pageUtil.totalPages ?? 1;
+  const items = useMemo(() => {
+    const base = data?.items ?? [];
+    const trimmed = query.trim().toLowerCase();
+    if (!trimmed) return base;
+    return base.filter(item => item.title.toLowerCase().includes(trimmed));
+  }, [data?.items, query]);
+  const totalPages = data?.pageUtil?.totalPages ?? 1;
 
   return (
     <div>
@@ -54,10 +61,32 @@ function CommunityPageContent() {
         <div className="h-16" />
         <div className="flex flex-row justify-between w-full px-[124px]">
           <div className="flex flex-row gap-3">
-            <CustomButton className="bg-grey-300 text-button text-brown rounded-[8px] px-[31px] py-[11.5px]">
+            <CustomButton
+              type="button"
+              onClick={() => {
+                setSelectedCategory('FREE');
+                setCurrentPage(1);
+              }}
+              className={
+                selectedCategory === 'FREE'
+                  ? 'bg-yellow-main text-button text-brown rounded-[8px] px-[31px] py-[11.5px]'
+                  : 'bg-grey-300 text-button text-brown rounded-[8px] px-[31px] py-[11.5px]'
+              }
+            >
               자유
             </CustomButton>
-            <CustomButton className="bg-yellow-main text-button text-brown rounded-[8px] px-[31px] py-[11.5px]">
+            <CustomButton
+              type="button"
+              onClick={() => {
+                setSelectedCategory('QUESTION');
+                setCurrentPage(1);
+              }}
+              className={
+                selectedCategory === 'QUESTION'
+                  ? 'bg-yellow-main text-button text-brown rounded-[8px] px-[31px] py-[11.5px]'
+                  : 'bg-grey-300 text-button text-brown rounded-[8px] px-[31px] py-[11.5px]'
+              }
+            >
               질문
             </CustomButton>
           </div>
@@ -79,13 +108,13 @@ function CommunityPageContent() {
               items.map(item => (
                 <Link href={`/community/${item.id}`} key={item.id}>
                   <DrinkCard
-                    title={item.name}
-                    author={item.category}
-                    imageUrl={item.image ?? '/images/whisky.png'}
-                    avatarUrl="/images/avatar.png"
-                    likes={item.wish}
+                    title={item.title}
+                    author={item.author?.nickname ?? 'Unknown'}
+                    imageUrl={item.imageUrl ?? '/images/whisky.png'}
+                    avatarUrl={item.author?.profileImageUrl ?? '/images/avatar.png'}
+                    likes={item.likeCnt}
                     views={item.viewCnt}
-                    comments={item.noteCnt}
+                    comments={item.commentCnt}
                   />
                 </Link>
               ))}

--- a/src/app/community/page.tsx
+++ b/src/app/community/page.tsx
@@ -50,17 +50,20 @@ function CommunityPageContent() {
   return (
     <div>
       <BoardHeader />
-      <main className="pt-25 flex flex-col items-center w-full">
-        <Searchbar
-          placeholder="커뮤니티 검색"
-          onSearch={nextQuery => {
-            setCurrentPage(1);
-            setQuery(nextQuery.trim());
-          }}
-        />
-        <div className="h-16" />
-        <div className="flex flex-row justify-between w-full px-[124px]">
-          <div className="flex flex-row gap-3">
+      <main className="mx-auto flex w-full max-w-[1200px] flex-col px-5 pb-20 pt-8 sm:px-8 sm:pt-10 lg:px-10">
+        <div className="flex justify-center">
+          <Searchbar
+            className="max-w-[726px]"
+            placeholder="커뮤니티 검색"
+            onSearch={nextQuery => {
+              setCurrentPage(1);
+              setQuery(nextQuery.trim());
+            }}
+          />
+        </div>
+        <div className="h-8 sm:h-12" />
+        <div className="flex items-start justify-between gap-4 sm:items-center">
+          <div className="flex flex-wrap gap-3">
             <CustomButton
               type="button"
               onClick={() => {
@@ -69,8 +72,8 @@ function CommunityPageContent() {
               }}
               className={
                 selectedCategory === 'FREE'
-                  ? 'bg-yellow-main text-button text-brown rounded-[8px] px-[31px] py-[11.5px]'
-                  : 'bg-grey-300 text-button text-brown rounded-[8px] px-[31px] py-[11.5px]'
+                  ? 'rounded-[8px] bg-yellow-main px-6 py-2.5 text-button text-brown'
+                  : 'rounded-[8px] bg-grey-300 px-6 py-2.5 text-button text-brown'
               }
             >
               자유
@@ -83,8 +86,8 @@ function CommunityPageContent() {
               }}
               className={
                 selectedCategory === 'QUESTION'
-                  ? 'bg-yellow-main text-button text-brown rounded-[8px] px-[31px] py-[11.5px]'
-                  : 'bg-grey-300 text-button text-brown rounded-[8px] px-[31px] py-[11.5px]'
+                  ? 'rounded-[8px] bg-yellow-main px-6 py-2.5 text-button text-brown'
+                  : 'rounded-[8px] bg-grey-300 px-6 py-2.5 text-button text-brown'
               }
             >
               질문
@@ -92,15 +95,15 @@ function CommunityPageContent() {
           </div>
           <CustomButton
             onClick={() => router.push('/community/write')}
-            className="flex border-2 border-brown text-brown rounded-[8px] bg-transparent flex-row items-center py-2.5 px-4.5 gap-[9px]"
+            className="flex w-fit shrink-0 flex-row items-center gap-[9px] rounded-[8px] border-2 border-brown bg-transparent px-4 py-2.5 text-brown"
           >
-            <NewPost className="size-6 text-brown" />새 글 쓰기
+            <NewPost className="size-5 text-brown sm:size-6" />새 글 쓰기
           </CustomButton>
         </div>
         <div className="h-6" />
 
-        <div className="flex justify-start w-full px-[124px]">
-          <div className="grid grid-cols-3 max-2xl:grid-cols-2 max-lg:grid-cols-1 gap-5">
+        <div className="w-full">
+          <div className="grid grid-cols-1 gap-5 md:grid-cols-2 xl:grid-cols-3">
             {isLoading && <p className="text-grey-700">불러오는 중...</p>}
             {isError && <p className="text-grey-700">목록을 불러오지 못했습니다.</p>}
             {!isLoading &&
@@ -121,13 +124,13 @@ function CommunityPageContent() {
           </div>
         </div>
 
-        <div className="h-25" />
+        <div className="h-12 sm:h-16" />
         <PostsPagination
           currentPage={currentPage}
-          totalPages={totalPages}
+          totalPages={Math.max(1, totalPages)}
           onPageChange={setCurrentPage}
         />
-        <div className="h-[293px]" />
+        <div className="h-12 sm:h-20" />
       </main>
     </div>
   );

--- a/src/app/mypage/edit/page.tsx
+++ b/src/app/mypage/edit/page.tsx
@@ -1,0 +1,243 @@
+'use client';
+
+import { ChangeEvent, useEffect, useMemo, useRef, useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Camera, ChevronLeft, LoaderCircle, Trash2 } from 'lucide-react';
+import { toast } from 'sonner';
+import AuthGuard from '@/components/auth/AuthGuard';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { fileToDataUrl, updateMyProfile } from '@/api/user';
+import { getNicknameFallback } from '@/lib/user-profile';
+import { myProfileQueryOptions } from '@/query/options/user';
+
+const MAX_IMAGE_SIZE_BYTES = 5 * 1024 * 1024;
+
+export default function MyProfileEditPage() {
+  return (
+    <AuthGuard>
+      <MyProfileEditContent />
+    </AuthGuard>
+  );
+}
+
+function MyProfileEditContent() {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const imageInputRef = useRef<HTMLInputElement>(null);
+  const { data: profile, isLoading } = useQuery(myProfileQueryOptions);
+  const [nickname, setNickname] = useState('');
+  const [profileImageUrl, setProfileImageUrl] = useState<string | null>(null);
+  const [isInitialized, setIsInitialized] = useState(false);
+
+  useEffect(() => {
+    if (!profile || isInitialized) {
+      return;
+    }
+
+    setNickname(profile.nickname);
+    setProfileImageUrl(profile.profileImageUrl);
+    setIsInitialized(true);
+  }, [isInitialized, profile]);
+
+  const trimmedNickname = nickname.trim();
+  const nicknameError = useMemo(() => {
+    if (trimmedNickname.length === 0) return '닉네임을 입력해 주세요.';
+    if (trimmedNickname.length < 2 || trimmedNickname.length > 20) {
+      return '닉네임은 2자 이상 20자 이하로 입력해 주세요.';
+    }
+
+    return null;
+  }, [trimmedNickname]);
+
+  const hasChanges = !!profile && (
+    trimmedNickname !== profile.nickname || profileImageUrl !== profile.profileImageUrl
+  );
+
+  const updateProfileMutation = useMutation({
+    mutationFn: async () =>
+      updateMyProfile({
+        nickname: trimmedNickname,
+        profileImageUrl,
+      }),
+    onSuccess: updatedProfile => {
+      queryClient.setQueryData(myProfileQueryOptions.queryKey, updatedProfile);
+      toast.success('프로필을 저장했어요.', { duration: 1200 });
+      router.replace('/mypage');
+      router.refresh();
+    },
+    onError: error => {
+      const message = error instanceof Error ? error.message : '프로필 저장 중 문제가 발생했어요.';
+      toast.error(message, { duration: 1400 });
+    },
+  });
+
+  const handleSelectImage = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+
+    if (!file) {
+      return;
+    }
+
+    if (!file.type.startsWith('image/')) {
+      toast.error('이미지 파일만 업로드할 수 있어요.', { duration: 1400 });
+      event.target.value = '';
+      return;
+    }
+
+    if (file.size > MAX_IMAGE_SIZE_BYTES) {
+      toast.error('이미지는 5MB 이하로 선택해 주세요.', { duration: 1400 });
+      event.target.value = '';
+      return;
+    }
+
+    try {
+      const dataUrl = await fileToDataUrl(file);
+      setProfileImageUrl(dataUrl);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : '이미지를 불러오지 못했어요.';
+      toast.error(message, { duration: 1400 });
+    } finally {
+      event.target.value = '';
+    }
+  };
+
+  const handleRemoveImage = () => {
+    setProfileImageUrl(null);
+  };
+
+  const handleSubmit = async () => {
+    if (nicknameError) {
+      toast.error(nicknameError, { duration: 1400 });
+      return;
+    }
+
+    if (!hasChanges || updateProfileMutation.isPending) {
+      return;
+    }
+
+    await updateProfileMutation.mutateAsync();
+  };
+
+  return (
+    <main className="min-h-[calc(100vh-8rem)] bg-grey-100 px-4 py-6 md:px-8 md:py-10 lg:px-20">
+      <div className="mx-auto max-w-3xl">
+        <Link
+          href="/mypage"
+          className="mb-4 inline-flex items-center gap-1 text-body3 font-medium text-grey-700"
+        >
+          <ChevronLeft className="size-4" />
+          마이페이지로 돌아가기
+        </Link>
+
+        <Card className="rounded-3xl border-none shadow-sm">
+          <CardHeader className="space-y-2 p-6 md:p-8">
+            <CardTitle className="text-[clamp(1.75rem,5vw,2.25rem)] font-bold text-dark-brown">
+              프로필 편집
+            </CardTitle>
+            <p className="text-body3 text-grey-700">
+              사진과 닉네임을 수정할 수 있어요.
+            </p>
+          </CardHeader>
+
+          <CardContent className="space-y-8 p-6 pt-0 md:p-8 md:pt-0">
+            {isLoading || !profile ? (
+              <div className="flex min-h-64 items-center justify-center text-body3 text-grey-700">
+                프로필 정보를 불러오는 중...
+              </div>
+            ) : (
+              <>
+                <section className="flex flex-col items-center rounded-2xl bg-[#FFF8E1] px-5 py-8 text-center">
+                  <Avatar className="size-28 ring-4 ring-white md:size-32">
+                    <AvatarImage src={profileImageUrl ?? '/images/avatar.png'} alt="profile preview" />
+                    <AvatarFallback className="bg-yellow-main text-xl font-bold text-black">
+                      {getNicknameFallback(trimmedNickname || profile.nickname)}
+                    </AvatarFallback>
+                  </Avatar>
+
+                  <div className="mt-5 flex flex-wrap items-center justify-center gap-3">
+                    <Button
+                      type="button"
+                      className="bg-brown text-white hover:bg-brown/90"
+                      onClick={() => imageInputRef.current?.click()}
+                    >
+                      <Camera className="size-4" />
+                      사진 변경
+                    </Button>
+                    <Button type="button" variant="outline" onClick={handleRemoveImage}>
+                      <Trash2 className="size-4" />
+                      사진 제거
+                    </Button>
+                  </div>
+
+                  <input
+                    ref={imageInputRef}
+                    type="file"
+                    accept="image/*"
+                    className="hidden"
+                    onChange={handleSelectImage}
+                  />
+
+                  <p className="mt-3 text-caption text-grey-700">
+                    JPG, PNG, WEBP 파일을 5MB 이하로 업로드해 주세요.
+                  </p>
+                </section>
+
+                <section className="space-y-3">
+                  <Label htmlFor="nickname" className="text-body3 font-semibold text-brown">
+                    닉네임
+                  </Label>
+                  <Input
+                    id="nickname"
+                    value={nickname}
+                    maxLength={20}
+                    onChange={event => setNickname(event.target.value)}
+                    placeholder="닉네임을 입력해 주세요"
+                    className="h-12 rounded-xl border-grey-300 bg-white px-4 text-body3"
+                  />
+                  <div className="flex items-center justify-between text-caption">
+                    <p className={nicknameError ? 'text-red-500' : 'text-grey-700'}>
+                      {nicknameError ?? '2자 이상 20자 이하로 입력할 수 있어요.'}
+                    </p>
+                    <span className="text-grey-600">{trimmedNickname.length}/20</span>
+                  </div>
+                </section>
+
+                <div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    className="h-11 px-6"
+                    onClick={() => router.push('/mypage')}
+                  >
+                    취소
+                  </Button>
+                  <Button
+                    type="button"
+                    className="h-11 bg-yellow-main px-6 text-black hover:bg-yellow-500"
+                    disabled={!hasChanges || !!nicknameError || updateProfileMutation.isPending}
+                    onClick={handleSubmit}
+                  >
+                    {updateProfileMutation.isPending ? (
+                      <>
+                        <LoaderCircle className="size-4 animate-spin" />
+                        저장 중...
+                      </>
+                    ) : (
+                      '저장하기'
+                    )}
+                  </Button>
+                </div>
+              </>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </main>
+  );
+}

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -136,17 +136,17 @@ function MyPageContent() {
     {
       id: 1,
       postTitle: '입문자를 위한 위스키 추천 5선',
-      comment: 'ㄴ 저는 글렌리벳 12년도 정말 추천해요.',
+      comment: ' 저는 글렌리벳 12년도 정말 추천해요.',
     },
     {
       id: 2,
       postTitle: '요즘 빠진 조합: 아벨라워 + 다크초콜릿',
-      comment: 'ㄴ 이 조합 진짜 공감입니다. 피트향에도 잘 어울려요.',
+      comment: ' 이 조합 진짜 공감입니다. 피트향에도 잘 어울려요.',
     },
     {
       id: 3,
       postTitle: '테이스팅노트 어떻게 쓰고 계신가요?',
-      comment: 'ㄴ 향/맛/피니시를 나눠서 쓰니 훨씬 정리되더라고요.',
+      comment: ' 향/맛/피니시를 나눠서 쓰니 훨씬 정리되더라고요.',
     },
   ];
 
@@ -219,7 +219,7 @@ function DashboardSection({
   children: ReactNode;
 }) {
   return (
-    <Card className="rounded-2xl border-none shadow-sm overflow-hidden">
+    <Card className="overflow-hidden rounded-2xl border-none py-0 shadow-sm">
       <div className="flex items-center justify-between bg-yellow-main px-4 py-3 md:px-5">
         <h2 className="text-[1.55rem] font-semibold leading-[1.2] text-black md:text-head6">{title}</h2>
         <Link
@@ -229,7 +229,7 @@ function DashboardSection({
           more <ChevronRight className="size-4" />
         </Link>
       </div>
-      <CardContent className="p-3.5 md:p-5">{children}</CardContent>
+      <CardContent className="px-3.5 pb-3.5 pt-0 md:px-5 md:pb-5 md:pt-0">{children}</CardContent>
     </Card>
   );
 }
@@ -268,11 +268,18 @@ function ActivityGrid({ items }: { items: ActivityItem[] }) {
 
 function CommentList({ items }: { items: CommentItem[] }) {
   return (
-    <ul className="space-y-4">
-      {items.map(item => (
-        <li key={item.id} className="rounded-lg border border-grey-200 bg-white px-4 py-3">
-          <p className="text-body3 font-semibold text-black">{item.postTitle}</p>
-          <p className="mt-1 text-body3 text-grey-700">{item.comment}</p>
+    <ul>
+      {items.map((item, index) => (
+        <li
+          key={item.id}
+          className={index === 0 ? 'px-4 py-5 md:px-5' : 'border-t border-brown/40 px-4 py-5 md:px-5'}
+        >
+          <p className="text-body2 font-semibold leading-[1.35] text-black md:text-head6">
+            {item.postTitle}
+          </p>
+          <p className="mt-3 whitespace-pre-line text-body3 leading-[1.6] text-grey-800">
+            └ {item.comment}
+          </p>
         </li>
       ))}
     </ul>

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -3,16 +3,18 @@
 import Link from 'next/link';
 import Image from 'next/image';
 import { ReactNode } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { authQueryOptions } from '@/query/options/auth';
 import { wishAlcoholListQueryOptions } from '@/query/options/alcohol';
+import { logout } from '@/api/auth';
 import AuthGuard from '@/components/auth/AuthGuard';
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import ProfileSidebarCard from '@/components/profile/ProfileSidebarCard';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
-import { Separator } from '@/components/ui/separator';
-import { CalendarDays, ChevronRight, Eye, Heart, MessageCircle, MessageSquare, Pencil, Users } from 'lucide-react';
+import { myProfileQueryOptions } from '@/query/options/user';
+import { ChevronRight, Eye, Heart, MessageSquare } from 'lucide-react';
 
 type ActivityItem = {
   id: number | string;
@@ -40,7 +42,10 @@ export default function MyPage() {
 }
 
 function MyPageContent() {
-  const { data: userId, isLoading: isUserLoading } = useQuery(authQueryOptions);
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  useQuery(authQueryOptions);
+  const { data: profile, isLoading: isProfileLoading } = useQuery(myProfileQueryOptions);
   const {
     data: wishes,
     isLoading: isWishLoading,
@@ -145,58 +150,39 @@ function MyPageContent() {
     },
   ];
 
+  const handleLogout = async () => {
+    await logout();
+    // 임시: 로그아웃 시 인증 캐시 삭제
+    queryClient.removeQueries({ queryKey: ['auth', 'me'] });
+    queryClient.removeQueries({ queryKey: myProfileQueryOptions.queryKey });
+    router.replace('/login');
+  };
+
   return (
-    <main className="bg-grey-100 min-h-[calc(100vh-8rem)] px-6 py-10 md:px-12 lg:px-20">
+    <main className="bg-grey-100 min-h-[calc(100vh-8rem)] px-4 py-6 md:px-8 md:py-10 lg:px-20">
       <div className="mx-auto max-w-[1400px]">
-        <h1 className="text-head3 text-dark-brown mb-8">마이페이지</h1>
+        <h1 className="mb-5 text-[clamp(2rem,8vw,2.5rem)] font-bold leading-[1.2] text-dark-brown md:mb-8">
+          마이페이지
+        </h1>
 
-        <div className="grid grid-cols-1 xl:grid-cols-[320px_minmax(0,1fr)] gap-6 items-start">
-          <Card className="rounded-2xl border-none shadow-sm">
-            <CardContent className="p-6">
-              <div className="relative w-fit mx-auto">
-                <Avatar className="size-28 ring-4 ring-yellow-100">
-                  <AvatarImage src="/images/avatar.png" alt="profile" />
-                  <AvatarFallback>U</AvatarFallback>
-                </Avatar>
+        <div className="grid grid-cols-1 items-start gap-4 md:gap-6 xl:grid-cols-[320px_minmax(0,1fr)]">
+          <div className="space-y-4">
+            <ProfileSidebarCard variant="me" profile={profile} isLoading={isProfileLoading} />
+            <Card className="rounded-2xl border-none shadow-sm">
+              <CardContent className="p-5">
                 <Button
-                  size="icon"
-                  className="absolute -bottom-1 -right-1 size-9 rounded-full bg-yellow-main text-black hover:bg-yellow-500"
+                  type="button"
+                  variant="outline"
+                  className="h-10 w-full"
+                  onClick={handleLogout}
                 >
-                  <Pencil className="size-4" />
+                  로그아웃
                 </Button>
-              </div>
+              </CardContent>
+            </Card>
+          </div>
 
-              <div className="mt-6 text-center">
-                <p className="text-head5 text-brown font-bold">닉네임</p>
-                <div className="mt-3 flex items-center justify-center gap-6 text-body3 text-grey-700">
-                  <p>
-                    팔로잉 <span className="font-bold text-brown">128</span>
-                  </p>
-                  <p>
-                    팔로워 <span className="font-bold text-brown">324</span>
-                  </p>
-                </div>
-              </div>
-
-              <Separator className="my-6" />
-
-              <div className="space-y-3 text-body3 text-grey-700">
-                <div className="flex items-center gap-2">
-                  <CalendarDays className="size-4 text-brown" />
-                  <span>가입일: 2025.07.23</span>
-                </div>
-                <div className="flex items-center gap-2">
-                  <div className="inline-flex size-6 items-center justify-center rounded-full bg-yellow-main">
-                    <MessageCircle className="size-3.5 text-black" />
-                  </div>
-                  <span>카카오 로그인</span>
-                </div>
-                {!isUserLoading && <p className="text-caption text-grey-600">User ID: {userId}</p>}
-              </div>
-            </CardContent>
-          </Card>
-
-          <div className="space-y-5">
+          <div className="space-y-4 md:space-y-5">
             <DashboardSection title="Tasting Note" moreHref="/tasting-note">
               <ActivityGrid items={tastingNoteItems} />
             </DashboardSection>
@@ -234,31 +220,34 @@ function DashboardSection({
 }) {
   return (
     <Card className="rounded-2xl border-none shadow-sm overflow-hidden">
-      <div className="flex items-center justify-between bg-yellow-main px-5 py-3">
-        <h2 className="text-head6 text-black">{title}</h2>
-        <Link href={moreHref} className="inline-flex items-center gap-1 text-body3 font-semibold text-black">
+      <div className="flex items-center justify-between bg-yellow-main px-4 py-3 md:px-5">
+        <h2 className="text-[1.55rem] font-semibold leading-[1.2] text-black md:text-head6">{title}</h2>
+        <Link
+          href={moreHref}
+          className="inline-flex items-center gap-1 text-[0.82rem] font-semibold text-black md:text-body3"
+        >
           more <ChevronRight className="size-4" />
         </Link>
       </div>
-      <CardContent className="p-5">{children}</CardContent>
+      <CardContent className="p-3.5 md:p-5">{children}</CardContent>
     </Card>
   );
 }
 
 function ActivityGrid({ items }: { items: ActivityItem[] }) {
   return (
-    <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+    <div className="grid grid-cols-1 gap-3.5 md:gap-4 lg:grid-cols-2">
       {items.slice(0, 2).map(item => (
         <Link href={item.href} key={item.id}>
           <article className="rounded-xl overflow-hidden border border-grey-200 bg-white hover:shadow-sm transition-shadow">
-            <div className="relative h-36 bg-grey-100">
+            <div className="relative h-32 bg-grey-100 md:h-36">
               <Image src={item.imageUrl} alt={item.title} fill className="object-cover" />
               <Badge className="absolute right-2 top-2 bg-yellow-main text-black hover:bg-yellow-main">
                 <Heart className="mr-1 size-3.5 fill-black stroke-black" />
                 {item.likes}
               </Badge>
             </div>
-            <div className="px-4 py-3">
+            <div className="px-3.5 py-2.5 md:px-4 md:py-3">
               <h3 className="text-body2 font-semibold text-black truncate">{item.title}</h3>
               <p className="text-caption text-grey-700 mt-1">{item.author}</p>
               <div className="mt-2 flex items-center gap-3 text-caption text-grey-700">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -24,16 +24,26 @@ function HomeContent() {
   const hotCommunityPosts = data?.hotCommunityPosts?.length ? data.hotCommunityPosts : communityPosts;
 
   return (
-    <div className="flex-1">
-      <header className="relative w-full h-140">
-        <Image src="/images/main-banner.png" alt="Main Banner" fill className="object-cover" />
+    <div className="flex-1 w-full">
+      <header className="w-full px-4 md:px-6 lg:px-8">
+        <div className="mx-auto w-full max-w-[1200px]">
+          <div className="relative w-full aspect-[16/6] min-h-[180px] max-h-[420px] overflow-hidden">
+            <Image
+              src="/images/main-banner.png"
+              alt="Main Banner"
+              fill
+              className="object-cover object-center"
+              sizes="(max-width: 768px) 100vw, 1200px"
+            />
+          </div>
+        </div>
       </header>
-      <main className="flex flex-col gap-20 my-20">
+      <main className="mx-auto my-10 flex w-full max-w-[1200px] flex-col gap-12 px-4 md:my-14 md:gap-16 md:px-6 lg:px-8">
         <section>
-          <Title className="mx-35 mb-8">
+          <Title className="mb-5">
             <h2>Hot Tasting Note</h2>
           </Title>
-          <div className="overflow-x-auto py-14 pl-8 bg-grey-100 scrollbar-hide">
+          <div className="overflow-x-auto bg-grey-100 px-4 py-6 scrollbar-hide md:px-6">
             <div className="flex flex-row gap-6 w-max px-1">
               {hotTastingNotes.map(note => (
                 <DrinkCard
@@ -51,11 +61,11 @@ function HomeContent() {
           </div>
         </section>
         <section>
-          <Title className="mx-35">
+          <Title className="mb-5">
             <h2>Hot Community Post</h2>
           </Title>
-          <div className="bg-grey-100 px-40 py-10">
-            <div className="grid grid-rows-5 grid-flow-col gap-x-17 gap-y-2">
+          <div className="bg-grey-100 px-4 py-6 md:px-6 md:py-8 lg:px-8">
+            <div className="grid grid-cols-1 gap-x-10 gap-y-2 md:grid-cols-2">
               {hotCommunityPosts.map((post, index) => (
                 <HotCommunityPostCard
                   key={post.id}

--- a/src/app/profile/[userId]/page.tsx
+++ b/src/app/profile/[userId]/page.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { ReactNode, useMemo } from 'react';
+import { useParams } from 'next/navigation';
+import Link from 'next/link';
+import { useQuery } from '@tanstack/react-query';
+import ProfileSidebarCard from '@/components/profile/ProfileSidebarCard';
+import { Card, CardContent } from '@/components/ui/card';
+import { publicProfileQueryOptions } from '@/query/options/user';
+import { ChevronRight } from 'lucide-react';
+
+export default function PublicProfilePage() {
+  const params = useParams<{ userId: string }>();
+  const userId = Number(params.userId);
+  const queryOptions = useMemo(() => publicProfileQueryOptions(userId), [userId]);
+  const { data: profile, isLoading, isError } = useQuery({
+    ...queryOptions,
+    enabled: Number.isFinite(userId) && userId > 0,
+  });
+
+  return (
+    <main className="min-h-[calc(100vh-8rem)] bg-grey-100 px-4 py-6 md:px-8 md:py-10 lg:px-20">
+      <div className="mx-auto max-w-[1400px]">
+        <h1 className="mb-5 text-[clamp(2rem,8vw,2.5rem)] font-bold leading-[1.2] text-dark-brown md:mb-8">
+          Profile
+        </h1>
+
+        <div className="grid grid-cols-1 items-start gap-4 md:gap-6 xl:grid-cols-[320px_minmax(0,1fr)]">
+          <ProfileSidebarCard variant="public" profile={profile} isLoading={isLoading} />
+
+          <div className="space-y-4 md:space-y-5">
+            <ProfileSection title="Tasting Note" moreHref="/tasting-note">
+              {isError ? (
+                <p className="text-body3 text-grey-700">프로필 정보를 불러오지 못했어요.</p>
+              ) : (
+                <p className="text-body3 text-grey-700">
+                  {profile ? `${profile.nickname}님의 활동 목록이 여기에 들어갈 예정이에요.` : '프로필을 불러오는 중...'}
+                </p>
+              )}
+            </ProfileSection>
+
+            <ProfileSection title="Community Post" moreHref="/community">
+              <p className="text-body3 text-grey-700">공개 프로필에서도 같은 오른쪽 레이아웃을 이어서 붙일 수 있게 구성해 두었어요.</p>
+            </ProfileSection>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}
+
+function ProfileSection({
+  title,
+  moreHref,
+  children,
+}: {
+  title: string;
+  moreHref: string;
+  children: ReactNode;
+}) {
+  return (
+    <Card className="overflow-hidden rounded-2xl border-none shadow-sm">
+      <div className="flex items-center justify-between bg-yellow-main px-4 py-3 md:px-5">
+        <h2 className="text-[1.55rem] font-semibold leading-[1.2] text-black md:text-head6">{title}</h2>
+        <Link
+          href={moreHref}
+          className="inline-flex items-center gap-1 text-[0.82rem] font-semibold text-black md:text-body3"
+        >
+          more <ChevronRight className="size-4" />
+        </Link>
+      </div>
+      <CardContent className="p-5">{children}</CardContent>
+    </Card>
+  );
+}

--- a/src/app/tasting-note/page.tsx
+++ b/src/app/tasting-note/page.tsx
@@ -51,8 +51,8 @@ function TastingNotePageContent() {
 
   return (
     <main className="flex-1 pb-20">
-      <section className="bg-yellow-100">
-        <div className="mx-auto max-w-[1200px] px-5 py-10 sm:px-8 sm:py-12 md:px-10 md:py-14">
+      <section className="px-5 pt-6 sm:px-8 sm:pt-8 md:px-10 md:pt-10">
+        <div className="mx-auto max-w-[1200px] rounded-[24px] bg-yellow-100 px-5 py-10 sm:px-8 sm:py-12 md:px-10 md:py-14">
           <h1 className="text-[clamp(2.25rem,9vw,3rem)] font-bold text-black">Tasting Note</h1>
           <p className="mt-3 text-body2 text-grey-800 sm:text-body1">
             향과 맛을 잊기 전에 테이스팅 노트를 작성해보세요.

--- a/src/app/tasting-note/page.tsx
+++ b/src/app/tasting-note/page.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { Button } from '@/components/ui/button';
-import { Pen } from 'lucide-react';
+import { SquarePen } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import DrinkCard from '@/components/common/DrinkCard';
@@ -10,6 +9,16 @@ import PostsPagination from '@/components/common/PostsPagination';
 import Searchbar from '@/components/common/Searchbar';
 import { alcoholListQueryOptions } from '@/query/options/alcohol';
 import AuthGuard from '@/components/auth/AuthGuard';
+import CustomButton from '@/components/common/CustomButton';
+import type { AlcoholLabel } from '@/constants/enum/alcoholType';
+
+type TastingNoteCategory = AlcoholLabel;
+
+const CATEGORY_BUTTONS: { label: string; value: TastingNoteCategory }[] = [
+  { label: '위스키', value: '위스키' },
+  { label: '와인', value: '와인' },
+  { label: '기타', value: '기타' },
+];
 
 export default function TastingNotePage() {
   return (
@@ -22,6 +31,7 @@ export default function TastingNotePage() {
 function TastingNotePageContent() {
   const [currentPage, setCurrentPage] = useState(1);
   const [query, setQuery] = useState('');
+  const [selectedCategory, setSelectedCategory] = useState<TastingNoteCategory>('위스키');
 
   const queryOptions = useMemo(
     () =>
@@ -30,8 +40,9 @@ function TastingNotePageContent() {
         size: 9,
         sort: 'TastingNote',
         query,
+        category: selectedCategory,
       }),
-    [currentPage, query]
+    [currentPage, query, selectedCategory]
   );
 
   const { data, isLoading, isError } = useQuery(queryOptions);
@@ -39,22 +50,21 @@ function TastingNotePageContent() {
   const totalPages = data?.pageUtil.totalPages ?? 1;
 
   return (
-    <div className="flex-1">
-      <div className="container mx-auto px-6 py-8">
-        {/* 새글쓰기 버튼 */}
-        <div className="flex justify-end mb-6">
-          <Link href="/tasting-note/write" passHref>
-            {/* 임시 버튼, 필요시 삭제 */}
-            <Button className="bg-yellow-500 hover:bg-yellow-600 text-brown-800 font-medium">
-              <Pen className="w-4 h-4 mr-2" />
-              새글쓰기
-            </Button>
-          </Link>
+    <main className="flex-1 pb-20">
+      <section className="bg-yellow-100">
+        <div className="mx-auto max-w-[1200px] px-6 py-12 md:px-10 md:py-14">
+          <h1 className="text-head2 text-black">Tasting Note</h1>
+          <p className="mt-2 text-body2 text-grey-800">
+            향과 맛을 잊기 전에 테이스팅 노트를 작성해보세요.
+          </p>
         </div>
+      </section>
 
-        <div className="mb-8 flex justify-center">
+      <section className="mx-auto max-w-[1200px] px-6 pt-12 md:px-10 md:pt-14">
+        <div className="flex justify-center">
           <Searchbar
-            placeholder="테이스팅 노트 검색"
+            className="w-full max-w-[726px] shadow-none"
+            placeholder="검색어를 입력하세요"
             onSearch={nextQuery => {
               setCurrentPage(1);
               setQuery(nextQuery.trim());
@@ -62,26 +72,62 @@ function TastingNotePageContent() {
           />
         </div>
 
-        {isLoading && <p className="text-grey-700">불러오는 중...</p>}
-        {isError && <p className="text-grey-700">목록을 불러오지 못했습니다.</p>}
-
-        {!isLoading && !isError && (
-          <div className="grid grid-cols-3 max-2xl:grid-cols-2 max-lg:grid-cols-1 gap-5">
-            {items.map(item => (
-              <Link href={`/tasting-note/${item.id}`} key={item.id}>
-                <DrinkCard
-                  title={item.name}
-                  author={item.category}
-                  imageUrl={item.image ?? '/images/whisky.png'}
-                  avatarUrl="/images/avatar.png"
-                  likes={item.wish}
-                  views={item.viewCnt}
-                  comments={item.noteCnt}
-                />
-              </Link>
-            ))}
+        <div className="mt-10 flex flex-col gap-5 md:flex-row md:items-center md:justify-between">
+          <div className="flex flex-wrap gap-3">
+            {CATEGORY_BUTTONS.map(category => {
+              const isSelected = selectedCategory === category.value;
+              return (
+                <CustomButton
+                  key={category.value}
+                  type="button"
+                  onClick={() => {
+                    setSelectedCategory(category.value);
+                    setCurrentPage(1);
+                  }}
+                  className={
+                    isSelected
+                      ? 'rounded-[8px] bg-yellow-main px-6 py-2 text-button text-brown hover:bg-yellow-500'
+                      : 'rounded-[8px] bg-grey-300 px-6 py-2 text-button text-brown hover:bg-grey-400'
+                  }
+                >
+                  {category.label}
+                </CustomButton>
+              );
+            })}
           </div>
-        )}
+
+          <Link href="/tasting-note/write">
+            <CustomButton
+              className="rounded-[14px] border-2 border-brown bg-white px-5 py-3 text-head6 text-brown hover:bg-yellow-100"
+              icon={<SquarePen className="h-7 w-7 stroke-[2.2]" />}
+            >
+              새 글 쓰기
+            </CustomButton>
+          </Link>
+        </div>
+
+        <div className="mt-6">
+          {isLoading && <p className="text-grey-700">불러오는 중...</p>}
+          {isError && <p className="text-grey-700">목록을 불러오지 못했습니다.</p>}
+
+          {!isLoading && !isError && (
+            <div className="grid grid-cols-1 gap-5 md:grid-cols-2 xl:grid-cols-3">
+              {items.map(item => (
+                <Link href={`/tasting-note/${item.id}`} key={item.id}>
+                  <DrinkCard
+                    title={item.name}
+                    author={item.category}
+                    imageUrl={item.image ?? '/images/whisky.png'}
+                    avatarUrl="/images/avatar.png"
+                    likes={item.wish}
+                    views={item.viewCnt}
+                    comments={item.noteCnt}
+                  />
+                </Link>
+              ))}
+            </div>
+          )}
+        </div>
 
         <div className="h-16" />
         <PostsPagination
@@ -89,7 +135,7 @@ function TastingNotePageContent() {
           totalPages={Math.max(1, totalPages)}
           onPageChange={setCurrentPage}
         />
-      </div>
-    </div>
+      </section>
+    </main>
   );
 }

--- a/src/app/tasting-note/page.tsx
+++ b/src/app/tasting-note/page.tsx
@@ -52,18 +52,18 @@ function TastingNotePageContent() {
   return (
     <main className="flex-1 pb-20">
       <section className="bg-yellow-100">
-        <div className="mx-auto max-w-[1200px] px-6 py-12 md:px-10 md:py-14">
-          <h1 className="text-head2 text-black">Tasting Note</h1>
-          <p className="mt-2 text-body2 text-grey-800">
+        <div className="mx-auto max-w-[1200px] px-5 py-10 sm:px-8 sm:py-12 md:px-10 md:py-14">
+          <h1 className="text-[clamp(2.25rem,9vw,3rem)] font-bold text-black">Tasting Note</h1>
+          <p className="mt-3 text-body2 text-grey-800 sm:text-body1">
             향과 맛을 잊기 전에 테이스팅 노트를 작성해보세요.
           </p>
         </div>
       </section>
 
-      <section className="mx-auto max-w-[1200px] px-6 pt-12 md:px-10 md:pt-14">
+      <section className="mx-auto max-w-[1200px] px-5 pt-8 sm:px-8 sm:pt-10 md:px-10 md:pt-14">
         <div className="flex justify-center">
           <Searchbar
-            className="w-full max-w-[726px] shadow-none"
+            className="max-w-[726px] shadow-none"
             placeholder="검색어를 입력하세요"
             onSearch={nextQuery => {
               setCurrentPage(1);
@@ -72,8 +72,8 @@ function TastingNotePageContent() {
           />
         </div>
 
-        <div className="mt-10 flex flex-col gap-5 md:flex-row md:items-center md:justify-between">
-          <div className="flex flex-wrap gap-3">
+        <div className="mt-8 flex items-start justify-between gap-4 sm:mt-10 sm:items-center">
+          <div className="flex flex-wrap gap-2.5 sm:gap-3">
             {CATEGORY_BUTTONS.map(category => {
               const isSelected = selectedCategory === category.value;
               return (
@@ -86,8 +86,8 @@ function TastingNotePageContent() {
                   }}
                   className={
                     isSelected
-                      ? 'rounded-[8px] bg-yellow-main px-6 py-2 text-button text-brown hover:bg-yellow-500'
-                      : 'rounded-[8px] bg-grey-300 px-6 py-2 text-button text-brown hover:bg-grey-400'
+                      ? 'rounded-[8px] bg-yellow-main px-5 py-2 text-button text-brown hover:bg-yellow-500 sm:px-6'
+                      : 'rounded-[8px] bg-grey-300 px-5 py-2 text-button text-brown hover:bg-grey-400 sm:px-6'
                   }
                 >
                   {category.label}
@@ -98,8 +98,8 @@ function TastingNotePageContent() {
 
           <Link href="/tasting-note/write">
             <CustomButton
-              className="rounded-[14px] border-2 border-brown bg-white px-5 py-3 text-head6 text-brown hover:bg-yellow-100"
-              icon={<SquarePen className="h-7 w-7 stroke-[2.2]" />}
+              className="w-fit shrink-0 rounded-[14px] border-2 border-brown bg-white px-4 py-2.5 text-body2 font-semibold text-brown hover:bg-yellow-100 sm:px-5 sm:py-3 sm:text-head6"
+              icon={<SquarePen className="h-5 w-5 stroke-[2.2] sm:h-7 sm:w-7" />}
             >
               새 글 쓰기
             </CustomButton>
@@ -129,7 +129,7 @@ function TastingNotePageContent() {
           )}
         </div>
 
-        <div className="h-16" />
+        <div className="h-12 sm:h-16" />
         <PostsPagination
           currentPage={currentPage}
           totalPages={Math.max(1, totalPages)}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -9,27 +9,29 @@ export default function Footer() {
   if (isMobile)
     return (
       <footer
-        className="text-black gap-8 py-6 px-12 flex flex-col items-center justify-between"
+        className="flex flex-col items-center justify-between gap-6 px-4 py-6 text-black"
         style={{ backgroundColor: '#E6D3C2' }}
       >
-        <div className="py-6 px-4" style={{ backgroundColor: '#E6D3C2' }}>
+        <div className="px-2 py-2" style={{ backgroundColor: '#E6D3C2' }}>
           <img src="/logo/drinki-logo.png" alt="Drinki 로고" className="w-20" />
         </div>
 
-        <div className="flex flex-col items-center">
-          <div className="flex gap-4 text-xs mb-2">
+        <div className="flex w-full max-w-sm flex-col items-center">
+          <div className="mb-2 flex flex-wrap items-center justify-center gap-x-3 gap-y-1 text-xs">
             <Link href="#">개발진</Link>
             <Link href="#">이용약관</Link>
             <Link href="#">개인정보처리방침</Link>
             <Link href="#">고객센터</Link>
           </div>
-          <div className="text-xs">
-            사업자번호 <span>111-22-33333</span> | 문의{' '}
+          <div className="text-center text-xs">
+            사업자번호 <span>111-22-33333</span>
+            <br />
+            문의{' '}
             <a href="mailto:Drinki@gmail.com" className=" hover:text-yellow-300">
               Drinki@gmail.com
             </a>
           </div>
-          <div className="text-sm text-center mt-8">
+          <div className="mt-5 text-center text-xs">
             경고 : 지나친 음주는 뇌졸중, 기억력 손상이나 치매를 유발합니다. 임신 중 음주는 기형아
             출생 위험을 높입니다.
           </div>
@@ -38,7 +40,7 @@ export default function Footer() {
     );
   return (
     <footer
-      className="text-black py-12 px-24 flex flex-row items-center justify-between"
+      className="flex flex-row items-center justify-between px-24 py-12 text-black"
       style={{ backgroundColor: '#E6D3C2' }}
     >
       <div className="py-12 px-8" style={{ backgroundColor: '#E6D3C2' }}>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -8,8 +8,11 @@ export default function Footer() {
 
   if (isMobile)
     return (
-      <footer className="bg-brown text-white gap-8 py-6 px-12 flex flex-col items-center justify-between">
-        <div className="bg-white py-6 px-4">
+      <footer
+        className="text-black gap-8 py-6 px-12 flex flex-col items-center justify-between"
+        style={{ backgroundColor: '#E6D3C2' }}
+      >
+        <div className="py-6 px-4" style={{ backgroundColor: '#E6D3C2' }}>
           <img src="/logo/drinki-logo.png" alt="Drinki 로고" className="w-20" />
         </div>
 
@@ -34,8 +37,11 @@ export default function Footer() {
       </footer>
     );
   return (
-    <footer className="bg-brown text-white py-12 px-24 flex flex-row items-center justify-between">
-      <div className="bg-white py-12 px-8">
+    <footer
+      className="text-black py-12 px-24 flex flex-row items-center justify-between"
+      style={{ backgroundColor: '#E6D3C2' }}
+    >
+      <div className="py-12 px-8" style={{ backgroundColor: '#E6D3C2' }}>
         <img src="/logo/drinki-logo.png" alt="Drinki 로고" className="w-36" />
       </div>
 

--- a/src/components/common/BoardHeader.tsx
+++ b/src/components/common/BoardHeader.tsx
@@ -2,9 +2,13 @@ import React from 'react';
 
 export default function BoardHeader() {
   return (
-    <header className="pb-[22px] pt-[85px] pl-40 bg-yellow-100">
-      <h1 className="text-head2 text-black">community</h1>
-      <h2 className="text-body1 text-black">사람들과 자유롭게 의견을 나눠보세요.</h2>
+    <header className="bg-yellow-100 px-5 pb-6 pt-10 sm:px-8 sm:pb-8 sm:pt-14 lg:px-20">
+      <div className="mx-auto max-w-[1200px]">
+        <h1 className="text-[clamp(2rem,7vw,3rem)] font-bold text-black">community</h1>
+        <h2 className="mt-2 text-body2 text-black sm:text-body1">
+          사람들과 자유롭게 의견을 나눠보세요.
+        </h2>
+      </div>
     </header>
   );
 }

--- a/src/components/common/DrinkCard.tsx
+++ b/src/components/common/DrinkCard.tsx
@@ -21,36 +21,36 @@ export default function DrinkCard({
   author,
   imageUrl,
   avatarUrl,
-      likes,
-      views,
-      comments,
+  likes,
+  views,
+  comments,
 }: DrinkCardProps) {
   return (
-    <Card className="w-[24rem] h-[18rem] flex flex-col items-start rounded-xl overflow-hidden gap-0 p-0">
-      <div className="relative w-full h-[13rem]">
+    <Card className="flex h-[14rem] w-[10.5rem] flex-col items-start gap-0 overflow-hidden rounded-xl p-0 sm:h-[16rem] sm:w-[14rem] md:h-[18rem] md:w-[20rem]">
+      <div className="relative h-[9rem] w-full sm:h-[10.5rem] md:h-[13rem]">
         <Image
           src={imageUrl}
           alt={title}
           fill
           className="object-cover"
-          sizes="(max-width: 768px) 100vw, (max-width: 1280px) 50vw, 384px"
+          sizes="(max-width: 640px) 168px, (max-width: 768px) 224px, 320px"
         />
-        <div className="absolute text-caption top-2.5 right-2.5 bg-yellow-100 px-2 py-1 rounded-[0.375rem] flex items-center gap-1">
+        <div className="absolute top-2 right-2 flex items-center gap-1 rounded-[0.375rem] bg-yellow-100 px-1.5 py-0.5 text-[11px] sm:px-2 sm:py-1 sm:text-caption">
           <Heart />
           {likes}
         </div>
       </div>
-      <div className="w-full px-4.5 py-3.5 flex flex-col gap-2 items-start justify-center">
-        <h3 className="text-head6">{title}</h3>
+      <div className="flex w-full flex-col items-start justify-center gap-1.5 px-2.5 py-2.5 sm:gap-2 sm:px-3.5 sm:py-3">
+        <h3 className="line-clamp-1 text-[1.1rem] leading-[1.25] font-semibold sm:text-head6">{title}</h3>
         <div className="flex flex-row justify-between items-center w-full">
           <div className="flex items-center gap-2">
-            <Avatar className="w-5 h-5">
+            <Avatar className="h-4 w-4 sm:h-5 sm:w-5">
               <AvatarImage src={avatarUrl} />
-              <AvatarFallback>👤</AvatarFallback>
+              <AvatarFallback>N</AvatarFallback>
             </Avatar>
-            <span className="text-body3">{author}</span>
+            <span className="max-w-[5rem] truncate text-[12px] sm:max-w-none sm:text-body3">{author}</span>
           </div>
-          <div className="flex items-center gap-2 text-caption">
+          <div className="flex items-center gap-1.5 text-[11px] sm:gap-2 sm:text-caption">
             <div className="flex items-center gap-1">
               <Eye /> {views.toLocaleString()}
             </div>

--- a/src/components/common/DrinkCard.tsx
+++ b/src/components/common/DrinkCard.tsx
@@ -26,14 +26,14 @@ export default function DrinkCard({
   comments,
 }: DrinkCardProps) {
   return (
-    <Card className="flex h-[14rem] w-[10.5rem] flex-col items-start gap-0 overflow-hidden rounded-xl p-0 sm:h-[16rem] sm:w-[14rem] md:h-[18rem] md:w-[20rem]">
-      <div className="relative h-[9rem] w-full sm:h-[10.5rem] md:h-[13rem]">
+    <Card className="flex h-[15.5rem] w-full flex-col items-start gap-0 overflow-hidden rounded-xl p-0 sm:h-[16rem] md:h-[18rem] md:max-w-none">
+      <div className="relative h-[10rem] w-full sm:h-[10.5rem] md:h-[13rem]">
         <Image
           src={imageUrl}
           alt={title}
           fill
           className="object-cover"
-          sizes="(max-width: 640px) 168px, (max-width: 768px) 224px, 320px"
+          sizes="(max-width: 768px) 100vw, (max-width: 1280px) 50vw, 33vw"
         />
         <div className="absolute top-2 right-2 flex items-center gap-1 rounded-[0.375rem] bg-yellow-100 px-1.5 py-0.5 text-[11px] sm:px-2 sm:py-1 sm:text-caption">
           <Heart />
@@ -41,14 +41,18 @@ export default function DrinkCard({
         </div>
       </div>
       <div className="flex w-full flex-col items-start justify-center gap-1.5 px-2.5 py-2.5 sm:gap-2 sm:px-3.5 sm:py-3">
-        <h3 className="line-clamp-1 text-[1.1rem] leading-[1.25] font-semibold sm:text-head6">{title}</h3>
-        <div className="flex flex-row justify-between items-center w-full">
+        <h3 className="line-clamp-1 text-[1rem] leading-[1.25] font-semibold sm:text-head6">
+          {title}
+        </h3>
+        <div className="flex w-full flex-row items-center justify-between">
           <div className="flex items-center gap-2">
             <Avatar className="h-4 w-4 sm:h-5 sm:w-5">
               <AvatarImage src={avatarUrl} />
               <AvatarFallback>N</AvatarFallback>
             </Avatar>
-            <span className="max-w-[5rem] truncate text-[12px] sm:max-w-none sm:text-body3">{author}</span>
+            <span className="max-w-[6rem] truncate text-[12px] sm:max-w-none sm:text-body3">
+              {author}
+            </span>
           </div>
           <div className="flex items-center gap-1.5 text-[11px] sm:gap-2 sm:text-caption">
             <div className="flex items-center gap-1">

--- a/src/components/common/HotCommunityPostCard.tsx
+++ b/src/components/common/HotCommunityPostCard.tsx
@@ -14,15 +14,17 @@ export function HotCommunityPostCard({ index, title, href }: HotCommunityPostCar
     <Link href={href} className="block w-full">
       <div
         className={cn(
-          'cursor-pointer flex items-center py-2 gap-2 w-full rounded-[0.5rem] text-brown bg-white',
+          'cursor-pointer flex w-full items-center gap-2 rounded-[0.5rem] bg-white py-1.5 text-brown md:py-2',
           isFirst && 'bg-yellow-main'
         )}
       >
-        <span className="text-head4 shrink-0 px-4">{index + 1}</span>
+        <span className="shrink-0 px-3 text-[1.35rem] leading-none font-bold md:px-4 md:text-head4">
+          {index + 1}
+        </span>
         <p
           className={cn(
-            'text-body1 truncate whitespace-nowrap overflow-hidden min-w-0',
-            isFirst && 'text-head6'
+            'min-w-0 truncate whitespace-nowrap overflow-hidden text-[0.92rem] leading-6 md:text-body1',
+            isFirst && 'font-semibold md:text-head6'
           )}
         >
           {title}

--- a/src/components/common/PostsPagination.tsx
+++ b/src/components/common/PostsPagination.tsx
@@ -66,7 +66,7 @@ const PaginationPrevious = ({
     {...props}
   >
     <ChevronLeft className="h-4 w-4" />
-    <span>이전</span>
+    <span className="hidden sm:inline">이전</span>
   </PaginationLink>
 );
 PaginationPrevious.displayName = 'PaginationPrevious';
@@ -78,7 +78,7 @@ const PaginationNext = ({ className, ...props }: React.ComponentProps<typeof Pag
     className={cn('gap-1 pr-2.5', className)}
     {...props}
   >
-    <span>다음</span>
+    <span className="hidden sm:inline">다음</span>
     <ChevronRight className="h-4 w-4" />
   </PaginationLink>
 );
@@ -108,9 +108,13 @@ export default function PostsPagination({
   onPageChange,
 }: PostsPaginationProps) {
   const getVisiblePages = () => {
+    if (totalPages <= 1) {
+      return [1];
+    }
+
     const delta = 2;
-    const range = [];
-    const rangeWithDots = [];
+    const range: number[] = [];
+    const rangeWithDots: Array<number | '...'> = [];
 
     for (
       let i = Math.max(2, currentPage - delta);
@@ -134,12 +138,12 @@ export default function PostsPagination({
       rangeWithDots.push(totalPages);
     }
 
-    return rangeWithDots;
+    return [...new Set(rangeWithDots)];
   };
 
   return (
     <Pagination>
-      <PaginationContent>
+      <PaginationContent className="flex-wrap justify-center gap-2 sm:gap-1">
         <PaginationItem>
           <PaginationPrevious
             onClick={() => onPageChange(currentPage - 1)}
@@ -154,7 +158,7 @@ export default function PostsPagination({
               <PaginationLink
                 isActive={currentPage === page}
                 onClick={() => onPageChange(page as number)}
-                className="min-w-[40px]"
+                className="min-w-[40px] px-3 sm:px-4"
               >
                 {page}
               </PaginationLink>

--- a/src/components/common/Searchbar.tsx
+++ b/src/components/common/Searchbar.tsx
@@ -1,5 +1,4 @@
 import React, { useRef } from 'react';
-import { ArrowRight } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import Search from '../svg/Search';
 
@@ -29,7 +28,7 @@ export default function Searchbar({
   return (
     <div
       className={cn(
-        'rounded-[100px] relative h-fit w-fit shadow-[0_0_7px_rgba(0,0,0,0.1)] bg-transparent',
+        'relative h-fit w-full rounded-[100px] bg-transparent shadow-[0_0_7px_rgba(0,0,0,0.1)]',
         className
       )}
     >
@@ -38,9 +37,9 @@ export default function Searchbar({
         type="text"
         placeholder={placeholder}
         onKeyDown={handleKeyPress}
-        className="outline-brown max-lg:w-full outline-2 rounded-full w-[726px] px-10 py-4 text-head5 bg-transparent text-black placeholder:text-grey-700 focus:text-grey-900 placeholder:focus:text-gray-900"
+        className="outline-brown w-full rounded-full bg-transparent px-5 py-3 pr-14 text-[1.125rem] font-semibold text-black outline-2 placeholder:text-grey-700 focus:text-grey-900 sm:px-8 sm:py-4 sm:pr-18 sm:text-head5 placeholder:focus:text-gray-900"
       />
-      <Search className="absolute size-8 text-brown right-[40px] top-1/2 transform -translate-y-1/2" />
+      <Search className="absolute right-5 top-1/2 size-6 -translate-y-1/2 transform text-brown sm:right-8 sm:size-8" />
     </div>
   );
 }

--- a/src/components/common/Title.tsx
+++ b/src/components/common/Title.tsx
@@ -9,9 +9,11 @@ interface TitleProps {
 
 export default function Title({ className, children }: TitleProps) {
   return (
-    <div className={cn('flex flex-row items-center h-fit gap-0', className)}>
-      <span className="text-head3">{children}</span>
-      <ChevronRight className="size-12" />
+    <div className={cn('flex h-fit flex-row items-center gap-1 md:gap-0', className)}>
+      <span className="whitespace-nowrap text-[clamp(1.75rem,7.2vw,2.5rem)] leading-[1.2] font-bold">
+        {children}
+      </span>
+      <ChevronRight className="size-[clamp(1.75rem,6vw,3rem)]" />
     </div>
   );
 }

--- a/src/components/common/navibar/Navibar.tsx
+++ b/src/components/common/navibar/Navibar.tsx
@@ -30,26 +30,26 @@ export function Navibar() {
   }, [isDropdownOpen]);
 
   return (
-    <nav className="h-32 sticky top-0 z-50 w-full bg-white">
-      <div className="h-full container mx-auto flex items-center justify-between py-4 px-6">
-        <div className="flex flex-row justify-start items-center min-w-3/5 max-md:w-full">
+    <nav className="sticky top-0 z-50 h-20 w-full bg-white md:h-32">
+      <div className="container mx-auto flex h-full items-center justify-between px-4 py-3 md:px-6 md:py-4">
+        <div className="flex min-w-0 flex-1 flex-row items-center justify-start">
           <Link href="/">
             <img
               src="/logo/drinki-logo.png"
               alt="Drinki 로고"
-              className="w-36 rounded-xl hover:opacity-80 transition max-md:w-20"
+              className="w-22 rounded-xl transition hover:opacity-80 md:w-36"
             />
           </Link>
-          <div className="w-full text-dark-brown text-head6 ml-10 max-md:ml-0 flex flex-row items-center justify-start text-brown-800 font-medium">
+          <div className="ml-3 flex w-full min-w-0 flex-row items-center justify-start text-brown-800 md:ml-10">
             <div
               ref={dropdownRef}
-              className="flex-1 relative group flex items-center justify-center"
+              className="group relative flex flex-1 items-center justify-center"
             >
               <Button
                 variant="outline"
                 className={cn(
                   isMobile && isDropdownOpen && 'bg-yellow-500',
-                  'max-md:text-xs font-semibold border-0 w-full leading-none p-0 h-auto shadow-none text-[1.25rem] hover:bg-yellow-500 rounded-md'
+                  'h-auto w-full rounded-md border-0 p-0 text-[13px] leading-none font-semibold shadow-none hover:bg-yellow-500 md:text-[1.25rem]'
                 )}
                 onClick={() => setDropdownOpen(prev => !prev)}
               >
@@ -59,20 +59,20 @@ export function Navibar() {
             </div>
             <Link
               href="/tasting-note"
-              className="text-center leading-none py-0.5 max-md:text-xs hover:bg-yellow-500 flex-1 rounded-md"
+              className="flex-1 rounded-md py-0.5 text-center text-[13px] leading-none font-semibold hover:bg-yellow-500 md:text-[1.25rem]"
             >
               Tasting Note
             </Link>
             <Link
               href="/community"
-              className="leading-none py-0.5 max-md:text-xs text-center hover:bg-yellow-500 flex-1 rounded-md"
+              className="flex-1 rounded-md py-0.5 text-center text-[13px] leading-none font-semibold hover:bg-yellow-500 md:text-[1.25rem]"
             >
               Community
             </Link>
           </div>
         </div>
-        <Link href="/mypage">
-          <MypageIcon className={isMobile ? 'size-5' : ''} />
+        <Link href="/mypage" className="ml-3 shrink-0">
+          <MypageIcon className={isMobile ? 'size-4.5' : 'size-6'} />
         </Link>
       </div>
     </nav>

--- a/src/components/common/navibar/Navibar.tsx
+++ b/src/components/common/navibar/Navibar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 import { Button } from '../../ui/button';
 import { drinkCategories } from './const';
 import { cn } from '@/lib/utils';
@@ -12,6 +13,7 @@ import MypageIcon from '../../svg/MypageIcon';
 export function Navibar() {
   const [isDropdownOpen, setDropdownOpen] = useState(false);
   const isMobile = useIsMobile();
+  const pathname = usePathname();
   const dropdownRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
@@ -28,6 +30,10 @@ export function Navibar() {
       document.removeEventListener('mousedown', handleClickOutside);
     };
   }, [isDropdownOpen]);
+
+  const isDrinkActive = pathname.startsWith('/alcohol');
+  const isTastingNoteActive = pathname.startsWith('/tasting-note');
+  const isCommunityActive = pathname.startsWith('/community');
 
   return (
     <nav className="sticky top-0 z-50 h-20 w-full bg-white md:h-32">
@@ -48,26 +54,46 @@ export function Navibar() {
               <Button
                 variant="outline"
                 className={cn(
-                  isMobile && isDropdownOpen && 'bg-yellow-500',
-                  'h-auto w-full rounded-md border-0 p-0 text-[13px] leading-none font-semibold shadow-none hover:bg-yellow-500 md:text-[1.25rem]'
+                  'h-auto w-full rounded-md border-0 p-0 text-[13px] leading-none font-semibold text-brown-800 shadow-none hover:bg-transparent md:text-[1.25rem]'
                 )}
                 onClick={() => setDropdownOpen(prev => !prev)}
               >
-                Drink
+                <span
+                  className={cn(
+                    'inline-flex rounded-md px-2 py-1 hover:bg-yellow-500',
+                    isDrinkActive && 'text-orange-500'
+                  )}
+                >
+                  Drink
+                </span>
               </Button>
               <DrinkDropdownContent isOpen={isDropdownOpen} categories={drinkCategories} />
             </div>
             <Link
               href="/tasting-note"
-              className="flex-1 rounded-md py-0.5 text-center text-[13px] leading-none font-semibold hover:bg-yellow-500 md:text-[1.25rem]"
+              className="flex-1 py-0.5 text-center text-[13px] leading-none font-semibold text-brown-800 md:text-[1.25rem]"
             >
-              Tasting Note
+              <span
+                className={cn(
+                  'inline-flex rounded-md px-2 py-1 hover:bg-yellow-500',
+                  isTastingNoteActive && 'text-orange-500'
+                )}
+              >
+                Tasting Note
+              </span>
             </Link>
             <Link
               href="/community"
-              className="flex-1 rounded-md py-0.5 text-center text-[13px] leading-none font-semibold hover:bg-yellow-500 md:text-[1.25rem]"
+              className="flex-1 py-0.5 text-center text-[13px] leading-none font-semibold text-brown-800 md:text-[1.25rem]"
             >
-              Community
+              <span
+                className={cn(
+                  'inline-flex rounded-md px-2 py-1 hover:bg-yellow-500',
+                  isCommunityActive && 'text-orange-500'
+                )}
+              >
+                Community
+              </span>
             </Link>
           </div>
         </div>

--- a/src/components/profile/ProfileSidebarCard.tsx
+++ b/src/components/profile/ProfileSidebarCard.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import Link from 'next/link';
+import { MessageCircle, Pencil } from 'lucide-react';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { formatJoinDate, getNicknameFallback, getSocialTypeLabel } from '@/lib/user-profile';
+
+type BaseProfile = {
+  id: number;
+  nickname: string;
+  profileImageUrl: string | null;
+  wishCnt: number;
+  noteCnt: number;
+  createdAt: string | Date;
+};
+
+type OwnProfile = BaseProfile & {
+  socialType: string;
+};
+
+type PublicProfile = BaseProfile;
+
+type Props =
+  | {
+      variant: 'me';
+      profile?: OwnProfile;
+      isLoading?: boolean;
+    }
+  | {
+      variant: 'public';
+      profile?: PublicProfile;
+      isLoading?: boolean;
+    };
+
+export default function ProfileSidebarCard(props: Props) {
+  const isOwnProfile = props.variant === 'me';
+  const profile = props.profile;
+  const socialType = props.variant === 'me' ? props.profile?.socialType : undefined;
+  const nickname = props.isLoading ? '불러오는 중...' : profile?.nickname ?? '닉네임';
+
+  return (
+    <Card className="overflow-hidden rounded-[24px] border-none bg-white shadow-sm">
+      <CardContent className="px-7 py-8 md:px-8 md:py-10">
+        <div className="flex flex-col items-center text-center">
+          <div className="relative">
+            <Avatar className="size-36 border-[3px] border-yellow-main md:size-40">
+              <AvatarImage src={profile?.profileImageUrl ?? '/images/avatar.png'} alt="profile" />
+              <AvatarFallback className="bg-[#FFF8E1] text-[2rem] font-bold text-brown">
+                {getNicknameFallback(profile?.nickname ?? 'U')}
+              </AvatarFallback>
+            </Avatar>
+
+            {isOwnProfile && (
+              <Button
+                asChild
+                size="icon"
+                className="absolute bottom-1 right-0 size-11 rounded-full bg-yellow-main text-black shadow-none hover:bg-yellow-500"
+              >
+                <Link href="/mypage/edit" aria-label="프로필 편집">
+                  <Pencil className="size-5" />
+                </Link>
+              </Button>
+            )}
+          </div>
+
+          <h2 className="mt-12 text-[2rem] font-bold leading-none text-black">{nickname}</h2>
+
+          <div className="mt-10 grid w-full grid-cols-2 gap-10">
+            <ProfileCount label="팔로잉" value={0} />
+            <ProfileCount label="팔로워" value={0} />
+          </div>
+
+          <div className="mt-12 space-y-9">
+            <InfoBlock label="가입날짜" value={profile ? formatJoinDate(profile.createdAt) : '-'} />
+
+            {isOwnProfile ? (
+              <div className="space-y-4">
+                <p className="text-[1.1rem] font-semibold text-black">소셜로그인 타입</p>
+                <div className="mx-auto inline-flex h-12 w-12 items-center justify-center rounded-xl bg-yellow-main">
+                  <MessageCircle className="size-5 text-black" />
+                </div>
+                <p className="text-sm text-grey-700">
+                  {socialType ? getSocialTypeLabel(socialType) : '-'}
+                </p>
+              </div>
+            ) : (
+              <Button
+                type="button"
+                className="h-12 min-w-40 rounded-xl bg-yellow-main px-8 text-[1.1rem] font-semibold text-black hover:bg-yellow-500"
+              >
+                팔로우
+              </Button>
+            )}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function ProfileCount({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="space-y-4 text-center">
+      <p className="text-[1.1rem] font-semibold text-black">{label}</p>
+      <p className="text-[2rem] font-bold leading-none text-black">{String(value).padStart(3, '0')}</p>
+    </div>
+  );
+}
+
+function InfoBlock({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="space-y-4 text-center">
+      <p className="text-[1.1rem] font-semibold text-black">{label}</p>
+      <p className="text-[1.8rem] font-bold leading-none text-black">{value}</p>
+    </div>
+  );
+}

--- a/src/lib/user-profile.ts
+++ b/src/lib/user-profile.ts
@@ -1,0 +1,27 @@
+export function formatJoinDate(value: string | Date): string {
+  const date = value instanceof Date ? value : new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return '-';
+  }
+
+  return new Intl.DateTimeFormat('ko-KR', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(date);
+}
+
+export function getSocialTypeLabel(socialType: string): string {
+  const normalized = socialType.trim().toLowerCase();
+
+  if (normalized === 'google') return '구글 로그인';
+  if (normalized === 'kakao') return '카카오 로그인';
+  if (normalized === 'apple') return '애플 로그인';
+
+  return `${socialType} 로그인`;
+}
+
+export function getNicknameFallback(nickname: string): string {
+  return nickname.trim().charAt(0).toUpperCase() || 'U';
+}

--- a/src/query/options/user.ts
+++ b/src/query/options/user.ts
@@ -1,0 +1,13 @@
+import { queryOptions } from '@tanstack/react-query';
+import { getMyProfile, getPublicProfile } from '@/api/user';
+
+export const myProfileQueryOptions = queryOptions({
+  queryKey: ['user', 'myProfile'],
+  queryFn: getMyProfile,
+});
+
+export const publicProfileQueryOptions = (userId: number) =>
+  queryOptions({
+    queryKey: ['user', 'publicProfile', userId],
+    queryFn: () => getPublicProfile(userId),
+  });


### PR DESCRIPTION
## 1️⃣ 작업 내용 Summary

- 홈 화면 배너, 카드, 섹션 간격을 반응형 기준으로 정리했습니다.
- 네비게이션 바 active 상태를 추가하고 모바일 레이아웃을 개선했습니다.
- footer 색상과 레이아웃을 수정했습니다.
- 공통 UI 컴포넌트(`DrinkCard`, `Title`, `Searchbar`, `PostsPagination`, `HotCommunityPostCard`, `BoardHeader`)를 반응형 중심으로 리팩터링했습니다.
- 커뮤니티 페이지의 검색, 카테고리 필터, 새 글 쓰기 버튼 UI를 정리하고 필터가 동작하도록 연결했습니다.
- 마이페이지를 프로필 사이드바 + 활동 대시보드 구조로 개편했습니다.
- `ProfileSidebarCard`를 추가해 내 프로필/공개 프로필 UI를 공통화했습니다.
- 프로필 편집 페이지를 추가하고, 사용자 프로필 조회/수정 API 및 관련 query option을 연결했습니다.

## 2️⃣ 추후 작업할 내용

- 마이페이지/공개 프로필의 더미 데이터를 실제 API와 연결하기
- 팔로우 및 팔로잉 기능 연동하기
- 프로필 이미지 업로드 방식을 실제 업로드 플로우로 전환하기
- 
## 3️⃣ 체크리스트

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?

